### PR TITLE
Fix: Update to reverse when OG information is added to header

### DIFF
--- a/packages/studioCMS/src/integrations/studioCMSDashboard/routes/dashboard/components/BaseHead.astro
+++ b/packages/studioCMS/src/integrations/studioCMSDashboard/routes/dashboard/components/BaseHead.astro
@@ -62,7 +62,7 @@ const { title, description } = Astro.props;
 <meta name="title" content={title} />
 <meta name="description" content={description} />
 
-{isDashboardRoute(Astro.url.pathname) && (
+{ !isDashboardRoute(Astro.url.pathname) && (
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content='website' />
   <meta property="og:url" content={Astro.url} />


### PR DESCRIPTION
The dashboard does not need OG information displayed for its routes (this could also help improve security)

This was supposed to already be correct, but i missed a `!` to invert the option