### PR TITLE
Add astroENVConfig Utility, and migrate namespaceplugin to addVitePluin AIK Util

### DIFF
--- a/packages/studioCMS/src/coreIntegration.ts
+++ b/packages/studioCMS/src/coreIntegration.ts
@@ -1,6 +1,6 @@
 import { checkAstroConfig, studioLogger, studioLoggerOptsResolver, makeFrontend, addIntegrationArray, addIntegrationArrayWithCheck } from './utils';
 import { studioCMSRobotsTXT, studioCMSImageHandler, studioCMSDashboard } from './integrations';
-import { addDts, addVirtualImports, createResolver, defineIntegration } from 'astro-integration-kit';
+import { addDts, addVirtualImports, addVitePlugin, createResolver, defineIntegration } from 'astro-integration-kit';
 import 'astro-integration-kit/types/db';
 import { optionsResolver, vResolver } from './resolvers';
 // import inoxsitemap from '@inox-tools/sitemap-ext';
@@ -33,7 +33,7 @@ export default defineIntegration({
 				'astro:config:setup': async ( params ) => {
 
 					// Destructure Params
-					const { config: astroConfig, addWatchFile, updateConfig } = params;
+					const { config: astroConfig, addWatchFile } = params;
 
 					// Watch the StudioCMS Config File for changes (including creation/deletion)
 					addWatchFile(getStudioConfigFileUrl(astroConfig.root));
@@ -41,9 +41,8 @@ export default defineIntegration({
 					// Resolve Options
 					const resolvedOptions = await optionsResolver(params, options);
 
-					updateConfig({
-						vite: { plugins: [namespaceBuiltinsPlugin()] }
-					})
+					// Add Namespace Builtins Plugin for vite
+					addVitePlugin(params, { plugin: namespaceBuiltinsPlugin() })
 
 					// Create Runtime Logger
 					runtimeLogger(params, { name: "StudioCMS" })

--- a/packages/studioCMS/src/integrations/imageHandler/index.ts
+++ b/packages/studioCMS/src/integrations/imageHandler/index.ts
@@ -6,6 +6,7 @@ import { cloudflareImageHandler, netlifyImageHandler, nodeImageHandler, vercelIm
 import { optionsSchema } from './schemas';
 import { imageHandlerStrings } from './strings';
 import { componentResolver } from './componentResolver';
+import { addAstroEnvConfig } from '../../utils/astroEnvConfig';
 
 export default defineIntegration({
     name: '@astrolicious/studioCMS:imageHandler',
@@ -16,10 +17,7 @@ export default defineIntegration({
             hooks: {
                 "astro:config:setup": async ( params ) => {
 
-					const {
-						config: { adapter },
-						updateConfig,
-					} = params;
+					const { config: { adapter } } = params;
 
                     const { verbose, imageService: { cdnPlugin } } = options;
 
@@ -32,19 +30,15 @@ export default defineIntegration({
 						'@astrojs/netlify'
 					];
 
-					updateConfig({
-						experimental: {
-							env: {
-								schema: {
-									CMS_CLOUDINARY_CLOUDNAME: envField.string({
-										context: 'server',
-										access: 'secret',
-										optional: true,
-									})
-								}
-							}
+					addAstroEnvConfig(params,{
+						schema: {
+							CMS_CLOUDINARY_CLOUDNAME: envField.string({
+								context: 'server',
+								access: 'secret',
+								optional: true,
+							})
 						}
-					})
+					});
 
 					if (cdnPlugin === 'cloudinary-js') {
 						if (!env.CMS_CLOUDINARY_CLOUDNAME) {

--- a/packages/studioCMS/src/integrations/studioCMSDashboard/index.ts
+++ b/packages/studioCMS/src/integrations/studioCMSDashboard/index.ts
@@ -8,6 +8,7 @@ import { usernameAndPasswordAuthConfig } from "./studioauth-config";
 import type { IconifyJSON } from '@iconify/types';
 import { checkForWebVitals } from "./utils/vitals";
 import astrolace from '@matthiesenxyz/astrolace';
+import { addAstroEnvConfig } from "../../utils/astroEnvConfig";
 
 export default defineIntegration({
     name: '@astrolicious/studioCMS:adminDashboard',
@@ -31,9 +32,7 @@ export default defineIntegration({
 					loadKeys(params.logger, options);
 
 					// Update Astro Config with Environment Variables (`astro:env`)
-					params.updateConfig({ 
-						experimental: { env: astroENV } 
-					});
+					addAstroEnvConfig(params, astroENV)
 
 					// Virtual Imports and DTS File Creation
 					virtualResolver(params, { name });

--- a/packages/studioCMS/src/schemas/integrations.ts
+++ b/packages/studioCMS/src/schemas/integrations.ts
@@ -7,18 +7,20 @@ import { z } from 'astro/zod';
 export const includedIntegrationsSchema = z
 	.object({
 		/**
-		 * Allows the user to enable/disable the use of the Astro Robots Plugin
+		 * Allows the user to enable/disable the use of the StudioCMS Custom `astro-robots-txt` Integration
 		 * 
 		 * @default true
 		 */
 		useAstroRobots: z.boolean().optional().default(true),
 		astroRobotsConfig: z.custom<RobotsConfig>().default({}),
-		// /**
-		//  * Allows the user to enable/disable the use of the Inox-tools Sitemap Plugin
-		//  * For more information on the Inox-tools Sitemap Plugin, visit:
-		//  * @see https://inox-tools.vercel.app/sitemap-ext
-		//  * @default true
-		//  */
+		/**
+		 * Allows the user to enable/disable the use of the Inox-tools Sitemap Plugin
+		 * For more information on the Inox-tools Sitemap Plugin, visit:
+		 * @see https://inox-tools.vercel.app/sitemap-ext
+		 * 
+		 * # TEMPORARILY DISABLED
+		 * If you would like to still use the Inox-tools Sitemap Plugin, you can manually add it to your project's Integrations.
+		 */
 		useInoxSitemap: z.boolean().optional().default(true),
 	})
 	.optional()

--- a/packages/studioCMS/src/utils/astroEnvConfig.ts
+++ b/packages/studioCMS/src/utils/astroEnvConfig.ts
@@ -1,0 +1,16 @@
+import type { AstroConfig } from "astro";
+import { defineUtility } from "astro-integration-kit";
+
+
+export const addAstroEnvConfig = defineUtility("astro:config:setup")(
+    ( 
+            params, 
+            config: AstroConfig['experimental']['env']
+        ) => {
+
+        // Update Astro Config with Environment Variables (`astro:env`)
+        params.updateConfig({ 
+            experimental: { env: config } 
+        });
+
+        })


### PR DESCRIPTION
This PR does 2 things,

- Adds a new astroENVConfig AIK Utility to make it simplier to add new ENV Variables to astro:env
- Migrate the namespaceBuiltinsPlugin from `updateConfig()` to `addVitePlugin()`