### PR TITLE
add permissions for changeset action

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@v4

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -8,7 +8,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
-  issues: write
+  contents: write
   pull-requests: write
   
 jobs:

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -10,6 +10,17 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+  checks: read
+  deployments: read
+  discussions: read
+  packages: read
+  pages: read
+  repository-projects: read
+  security-events: read
+  statuses: read
   
 jobs:
   release:

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -7,6 +7,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  issues: write
+  pull-requests: write
+  
 jobs:
   release:
     name: Release


### PR DESCRIPTION
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#defining-access-for-the-github_token-scopes

Due to astrolicious policy i must apply the permissions to allow the workflow to interact with the repo (create releases and pull requests)

Permissions stolen from ATP... https://github.com/astrolicious/astro-theme-provider/blob/main/.github/workflows/release.yml

Src for what permissions should be required: https://github.com/changesets/action/issues/220#issuecomment-1382361385