### PR TITLE
Remove extra command that is apparently not needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "ci:install": "pnpm install --frozen-lockfile",
-    "ci:preversion": "pnpm changeset pre enter beta && pnpm changeset version",
+    "ci:preversion": "pnpm changeset version",
     "ci:version": "pnpm changeset version",
     "ci:publish": "pnpm changeset publish",
     "build:web": "pnpm --filter web build",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d32990ca-46f4-4032-b1ba-2c5f0b0965f3)

Removed the `changeset pre enter beta` as it is apparently only needed to move into and out of specific version tags and can continue to be used without exiting between merges