### PR TITLE
[fix] remove extra `]` from the code

### DIFF
--- a/.github/workflows/firsttimepr.yml
+++ b/.github/workflows/firsttimepr.yml
@@ -56,7 +56,7 @@ jobs:
                           },
                           "title": "🚨 FIRST TIME CONTRIBUTOR 🚨"
                         }
-                      ],],
+                      ],
                       components: [],
                       actions: {}
                     })


### PR DESCRIPTION
There was a stray extra `]` from the copy paste.  this removes the extra characters