### PR TITLE
Fix: Auth config not initializing unless explicitly enabled preventing firstTimeSetup from running

### DIFF
--- a/.changeset/polite-pandas-smile.md
+++ b/.changeset/polite-pandas-smile.md
@@ -1,0 +1,5 @@
+---
+"@astrolicious/studiocms": patch
+---
+
+Fix: Allow studiocms-auth.config.json to be created during first time database setup

--- a/packages/studioCMS/src/integrations/studioCMSDashboard/routes/databaseSetup/main.astro
+++ b/packages/studioCMS/src/integrations/studioCMSDashboard/routes/databaseSetup/main.astro
@@ -143,14 +143,14 @@ import { makePageTitle } from '../../utils/makePageTitle';
 		});
 		if (response.ok) {
       successMessageElement.innerText = "Successfully Seeded Database! Redirecting...";
-      logger.info('First Time Setup Success: Successfully Seeded Database');
+      console.log('First Time Setup Success: Successfully Seeded Database');
       successAlertElement.toast();
       setTimeout(() => {
         window.location.href = "/done";
       }, 1000)
 		} else {
 			errorMessageElement.innerText = (await response.json()).error;
-      logger.error(`First Time Setup Error: ${errorMessageElement.innerText}`);
+      console.log(`First Time Setup Error: ${errorMessageElement.innerText}`);
       alertElement.toast();
 		}
 	});

--- a/packages/studioCMS/src/integrations/studioCMSDashboard/studioauth-config.ts
+++ b/packages/studioCMS/src/integrations/studioCMSDashboard/studioauth-config.ts
@@ -58,7 +58,7 @@ export const usernameAndPasswordAuthConfig = defineUtility('astro:config:setup')
 			},
 		} = options;
 
-		const enabled = dashboardEnabled && authEnabled && allowUserRegistration;
+		const enabled = dashboardEnabled && authEnabled;
 
 		const AuthLogger = params.logger.fork('@astrolicious/studioCMS:adminDashboard/auth-security');
 

--- a/packages/studioCMS/src/integrations/studioCMSDashboard/studioauth-config.ts
+++ b/packages/studioCMS/src/integrations/studioCMSDashboard/studioauth-config.ts
@@ -64,10 +64,6 @@ export const usernameAndPasswordAuthConfig = defineUtility('astro:config:setup')
 
 		const LoggerOpts = await studioLoggerOptsResolver(AuthLogger, true);
 
-		if (!enabled) {
-			return;
-		}
-
 		if (dbStartPage || enabled) {
 			studioLogger(LoggerOpts.logInfo, authConfigStrings.configSetup);
 


### PR DESCRIPTION
Removes the redundant check that prevents the first time setup stage from being able to load the AuthSecurity config!