### PR TITLE
Update first time PR action

### DIFF
--- a/.github/workflows/firsttimepr.yml
+++ b/.github/workflows/firsttimepr.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   pull-requests: write
   actions: write
+  issues: write
 
 jobs:
   welcome:
@@ -22,16 +23,15 @@ jobs:
               const res = await github.rest.search.issuesAndPullRequests({
                 q: `is:pr is:closed author:${creator} repo:${owner}/${repo}`
               })
-    
+
               const mergedPRs = res.data.items.filter(pr => pr.number !== context.payload.pull_request.number)
-    
+
               if (mergedPRs.length === 0) {
-                try {
                   await github.rest.issues.createComment({
                     issue_number: context.issue.number,
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    body: `**Welcome** @${creator}, to the Contributor Squad! 🎉\n\nIf you haven't already, please join our Discord, https://chat.astrolicious.dev community to stay in the loop for any future help we may need!`
+                    body: `**Welcome** @${creator}, to the Contributor Squad! 🎉\n\nIf you haven't already, please join our [Discord community](https://chat.studiocms.xyz), to stay in the loop for any future help we may need!`
                   })
                   
                   await fetch(`${{ secrets.DISCORD_FTPR }}`, {
@@ -46,7 +46,7 @@ jobs:
                       embeds: [
                         {
                           "id": 661098315,
-                          "description": "New Contributor - ${{ inputs.creator }} has had their first PR merged! 🎉\nMerged PR: [PR# ${{ inputs.mergedPR }}](https://github.com/astrolicious/studiocms/pull/${{ inputs.mergedPR }})",
+                          "description": `New Contributor - ${creator} has had their first PR merged! 🎉\nMerged PR: [PR# ${context.issue.number}](https://github.com/astrolicious/studiocms/pull/${context.issue.number})`,
                           "fields": [],
                           "author": {
                             "name": "StudioCMS Contributor Alert",
@@ -57,12 +57,7 @@ jobs:
                       ],
                       components: [],
                       actions: {}
-                    })
                   })
-                } catch (error) {
-                    if (error.code !== 404) {
-                        throw error
-                    }
-                }
+                })
               }
             }


### PR DESCRIPTION
This pull request includes several updates to the `.github/workflows/firsttimepr.yml` file to enhance the workflow for welcoming new contributors. The most important changes include adding new permissions, updating the welcome message, and refining the logic for creating comments and handling errors.

Permissions update:

* Added `issues: write` permission to the workflow configuration.

Message and logic improvements:

* Updated the welcome message to include a link to the new Discord community.
* Refined the description in the Discord embed message to use template literals for dynamic content. and fixing the main error that was caused due to this not being done in the first place, and it still expecting the input values from the old workflow
* Removed the try-catch block that handled errors when creating comments, simplifying the code.