### PR TITLE
Remove TODO comments, small fixes to UI lib

### DIFF
--- a/packages/studiocms_ui/src/components/BaseHead.astro
+++ b/packages/studiocms_ui/src/components/BaseHead.astro
@@ -12,7 +12,7 @@ const { title, description, image, headers: userHeaders } = Astro.props;
 
 const canonicalURL = Astro.site ? new URL(Astro.url.pathname, Astro.site) : undefined;
 
-// TODO: Make this more customizable or move out of UI and into dashboard
+// This should probably be removed from the UI lib at some point
 const defaultHeaders = headDefaults(title, description, Astro, image, canonicalURL);
 
 const head = createHead(defaultHeaders, userHeaders || []);

--- a/packages/studiocms_ui/src/components/Button/Button.css
+++ b/packages/studiocms_ui/src/components/Button/Button.css
@@ -7,7 +7,7 @@
 
 	position: relative;
 
-	/* TODO: Move gaps & radii to spacings.css */
+	/* Move gaps & radii to spacings.css later on */
 	gap: 0.5rem;
 
 	outline: none;

--- a/packages/studiocms_ui/src/components/Dropdown/dropdown.ts
+++ b/packages/studiocms_ui/src/components/Dropdown/dropdown.ts
@@ -71,8 +71,6 @@ class DropdownHelper {
 
 		const isMobile = window.matchMedia('screen and (max-width: 840px)').matches;
 
-		// TODO: Figure out dropdowns on mobile: 100% of parent
-		// On desktop: max-width: min-content;
 		const {
 			bottom,
 			left,

--- a/packages/studiocms_ui/src/components/Sidebar/helpers.ts
+++ b/packages/studiocms_ui/src/components/Sidebar/helpers.ts
@@ -60,7 +60,6 @@ class SingleSidebarHelper {
 class DoubleSidebarHelper {
 	sidebarsContainer: HTMLElement;
 
-	// TODO: Rework into similar to single sidebar
 	constructor() {
 		const sidebarsContainer = document.getElementById('sidebars');
 

--- a/packages/studiocms_ui/src/components/User/User.astro
+++ b/packages/studiocms_ui/src/components/User/User.astro
@@ -1,6 +1,7 @@
 ---
 import './User.css';
 
+import { Image } from 'astro:assets';
 import Icon from '../../utils/Icon.astro';
 
 type Props = {
@@ -14,9 +15,9 @@ const { name, description, avatar, class: className } = Astro.props;
 ---
 <div class="user-container" class:list={[ className ]}>
   <div class="avatar-container">
-    <!-- TODO: Astro Image or Unpic? -->
+    <!-- Astro Image or Unpic -->
     {avatar ? (
-      <img src={avatar} class="avatar-img" />
+      <Image src={avatar} inferSize alt={name} class="avatar-img" />
     ) : (
       <Icon name='user' width={32} height={32} />
     )}

--- a/packages/studiocms_ui/src/css/resets.css
+++ b/packages/studiocms_ui/src/css/resets.css
@@ -43,9 +43,8 @@ code {
 	overflow-wrap: anywhere;
 }
 
-/* TODO: Move to layout & add mono font */
 code {
-	font-family: var(--__sl-font-mono);
+	font-family: monospace;
 }
 
 button {


### PR DESCRIPTION
#### Description

- Closes #320, #319, #318, #317, #316 and #315
    - All of these were erroneously created automatically based on leftover TODO comments in the recently merged `@studiocms/ui` package PR #296
- Fixes the monospace font in the `reset.css` file not setting a font and instead using an unset variable. 
- Fixes the `<User />` compnent using a default `<img>` tag instead of `<Image />` from `astro:assets`.