### PR TITLE
Update Deployment link helper

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -1,6 +1,8 @@
 name: StudioCMS Deployments
 
-on: pull_request_target
+on: 
+  pull_request_target:
+    types: [assigned, opened, reopened]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
This should prevent multiple messages being sent constantly as new commits are added.  only sending the links when opened/assigned/reopened