### PR TITLE
Update deployments link helper to use new service account

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Deployment Queued Comment
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
+          github-token: ${{ secrets.STUDIOCMS_SERVICE_TOKEN }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deployments.yml` file. The change adds a GitHub token to the `Deployment Queued Comment` job for authentication purposes.

* [`.github/workflows/deployments.yml`](diffhunk://#diff-281dc64b9ea3a0656a98c76ab8a9c3e9c576d90f291b222563015d58047d7159R18): Added `github-token` to the `Deployment Queued Comment` job to use the `STUDIOCMS_SERVICE_TOKEN` secret for authentication.