### PR TITLE
Update changeset-release.yml

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -38,6 +38,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+            setupGitUser: false
             commit: "👷 [ci]: Version Packages"
             title: "👷 [ci]: Ready for Release"
             version: pnpm ci:version


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/changeset-release.yml` file. The change involves setting up the `setupGitUser` parameter to `false` in the `changesets` job.  This should allow the GitHub action to inherit the user details from the `PAT`

* [`.github/workflows/changeset-release.yml`](diffhunk://#diff-0b5dfb21191138098228c2286dff689fca5a70c8101aabe19aade2a3363442ecR41): Added `setupGitUser: false` to the `changesets` job configuration.