### PR TITLE
Update deployments link helper domain names

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -38,7 +38,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-            setupGitUser: false
+            setupGitUser: true
             commit: "👷 [ci]: Version Packages"
             title: "👷 [ci]: Ready for Release"
             version: pnpm ci:version

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -22,8 +22,8 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `Thank you for submitting your Pull Request, the following links will become available for preview shortly:\n\n
-              - [StudioCMS Landing Page](https://pr${context.payload.pull_request.number}-www.studiocms.xyz/)\n
-              - [StudioCMS Documentation](https://pr${context.payload.pull_request.number}-docs.studiocms.xyz/)\n
-              - [StudioCMS Demo (node-playground)](https://pr${context.payload.pull_request.number}-demo.studiocms.xyz/) (Also deployed with package changes)\n
-              - [StudioCMS Ui Demo (ui-playground)](https://pr${context.payload.pull_request.number}-ui-testing.studiocms.xyz/)`
+              - [StudioCMS Landing Page](https://pr${context.payload.pull_request.number}.www.studiocms.xyz/)\n
+              - [StudioCMS Documentation](https://pr${context.payload.pull_request.number}.docs.studiocms.xyz/)\n
+              - [StudioCMS Demo (node-playground)](https://pr${context.payload.pull_request.number}.demo.studiocms.xyz/) (Also deployed with package changes)\n
+              - [StudioCMS Ui Demo (ui-playground)](https://pr${context.payload.pull_request.number}.ui-testing.studiocms.xyz/)`
             })


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows for release and deployment processes. The most important changes involve enabling the setup of the Git user for the changeset action and updating the URLs for preview links in the deployment workflow.

Changes to GitHub Actions workflows:

* [`.github/workflows/changeset-release.yml`](diffhunk://#diff-0b5dfb21191138098228c2286dff689fca5a70c8101aabe19aade2a3363442ecL41-R41): Enabled the setup of the Git user by changing `setupGitUser` from `false` to `true`. (This was supposed to be true, but i had copied the wrong example)
* [`.github/workflows/deployments.yml`](diffhunk://#diff-281dc64b9ea3a0656a98c76ab8a9c3e9c576d90f291b222563015d58047d7159L25-R28): Updated the URLs for preview links to use dots instead of hyphens in the subdomain parts.