### PR TITLE
add nvm install command to install correct node version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,6 @@ FROM mcr.microsoft.com/devcontainers/javascript-node:0-20
 
 # We uninstall pnpm here, since we enable the corepack version in the postCreateCommand
 # This ensures we respect the "packageManager" version in package.json
-RUN npm uninstall -g pnpm
+RUN npm uninstall -g pnpm && nvm install 20.14.0
 
 COPY welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,6 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "postStartCommand": "nvm install 20.14.0",
   "postCreateCommand": "sudo corepack enable pnpm && pnpm config set store-dir /home/node/.pnpm-store && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 pnpm install",
   "waitFor": "postCreateCommand",
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,8 +15,7 @@
         "astro-build.houston",
         "biomejs.biome",
         "eamodio.gitlens",
-        "redhat.vscode-yaml",
-        "ZainChen.json"
+        "redhat.vscode-yaml"
       ]
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "postCreateCommand": "nvm install 20.14.0 && sudo corepack enable pnpm && pnpm config set store-dir /home/node/.pnpm-store && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 pnpm install",
+  "postStartCommand": "nvm install 20.14.0",
+  "postCreateCommand": "sudo corepack enable pnpm && pnpm config set store-dir /home/node/.pnpm-store && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 pnpm install",
   "waitFor": "postCreateCommand",
   "customizations": {
     "codespaces": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,11 +3,8 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-
-  "postCreateCommand": "sudo corepack enable pnpm && pnpm config set store-dir /home/node/.pnpm-store && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 pnpm install",
-
+  "postCreateCommand": "nvm install 20.14.0 && sudo corepack enable pnpm && pnpm config set store-dir /home/node/.pnpm-store && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 pnpm install",
   "waitFor": "postCreateCommand",
-
   "customizations": {
     "codespaces": {
       "openFiles": ["README.md"]


### PR DESCRIPTION
This pull request includes a change to the `.devcontainer/devcontainer.json` file to update the `postCreateCommand` for better compatibility and setup.

Setup improvements:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L6-L10): Updated the `postCreateCommand` to include installing Node.js version 20.14.0 using `nvm` before enabling `pnpm` and configuring its store directory. This ensures the appropriate Node.js version is used in the development environment.

This PR was created from the new Coder server!