### PR TITLE
Fix studio heading in firefox

### DIFF
--- a/www/docs/src/components/StudioHeading.astro
+++ b/www/docs/src/components/StudioHeading.astro
@@ -101,6 +101,9 @@ rehype()
 		line-height: var(--sl-line-height-headings);
 		font-size: var(--sl-text-xs);
 		font-family: var(--__sl-font-mono);
+
+		/* Firefox */
+		z-index: -1;
 	}
 	:global([dir='rtl']) .studio-tag:not(:where([dir='rtl'] [dir='ltr'] *)) {
 		--highlight-position: 100%;


### PR DESCRIPTION
#### Description

- Fix the studio heading in Firefox using `z-index`
