### PR TITLE
Update dependencies in pnpm catalog

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@astrojs/check':
-      specifier: ^0.9.3
-      version: 0.9.3
+      specifier: ^0.9.4
+      version: 0.9.4
     '@astrojs/db':
       specifier: ^0.14.2
       version: 0.14.2
@@ -16,8 +16,8 @@ catalogs:
       specifier: ^5.2.0
       version: 5.2.0
     '@astrojs/node':
-      specifier: ^8.3.3
-      version: 8.3.3
+      specifier: ^8.3.4
+      version: 8.3.4
     '@astrojs/rss':
       specifier: ^4.0.7
       version: 4.0.7
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^0.28.3
       version: 0.28.3
     '@astrojs/tailwind':
-      specifier: ^5.1.0
-      version: 5.1.0
+      specifier: ^5.1.2
+      version: 5.1.2
     '@astrojs/web-vitals':
       specifier: ^3.0.0
       version: 3.0.0
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^20.14.11
       version: 20.14.13
     astro:
-      specifier: ^4.16.3
-      version: 4.16.3
+      specifier: ^4.16.6
+      version: 4.16.6
     astro-integration-kit:
       specifier: ^0.16.1
       version: 0.16.1
@@ -62,26 +62,26 @@ catalogs:
       specifier: ^3.0.4
       version: 3.0.4
     astro-embed:
-      specifier: ^0.7.2
-      version: 0.7.2
+      specifier: ^0.7.4
+      version: 0.7.4
     hast:
       specifier: ^1.0.0
       version: 1.0.0
     hast-util-select:
-      specifier: ^6.0.2
-      version: 6.0.2
+      specifier: ^6.0.3
+      version: 6.0.3
     p-retry:
       specifier: ^6.2.0
       version: 6.2.0
     rehype:
-      specifier: ^13.0.1
-      version: 13.0.1
+      specifier: ^13.0.2
+      version: 13.0.2
     starlight-typedoc:
       specifier: ^0.16.0
       version: 0.16.0
     typedoc:
-      specifier: ^0.26.8
-      version: 0.26.8
+      specifier: ^0.26.10
+      version: 0.26.10
     typedoc-plugin-markdown:
       specifier: ^4.2.9
       version: 4.2.9
@@ -96,17 +96,17 @@ catalogs:
       specifier: ^10.18.0
       version: 10.18.0
     powerglitch:
-      specifier: ^2.3.3
-      version: 2.3.3
+      specifier: ^2.3.4
+      version: 2.3.4
     tailwind-merge:
-      specifier: ^2.5.2
-      version: 2.5.2
+      specifier: ^2.5.4
+      version: 2.5.4
     tailwind-scrollbar:
       specifier: ^3.1.0
       version: 3.1.0
     tailwindcss:
-      specifier: ^3.4.4
-      version: 3.4.7
+      specifier: ^3.4.14
+      version: 3.4.14
   min:
     '@astrojs/db':
       specifier: '>=0.14.2'
@@ -133,11 +133,11 @@ catalogs:
       version: 11.1.0
   studiocms-imagehandler:
     '@cloudinary/url-gen':
-      specifier: ^1.19.0
-      version: 1.19.0
+      specifier: ^1.21.0
+      version: 1.21.0
     '@unpic/astro':
-      specifier: ^0.0.46
-      version: 0.0.46
+      specifier: ^0.0.47
+      version: 0.0.47
   studiocms-renderer:
     '@mdx-js/mdx':
       specifier: ^3.0.1
@@ -174,11 +174,11 @@ catalogs:
       specifier: 5.1.0
       version: 5.1.0
     '@iconify-json/heroicons':
-      specifier: ^1.2.0
-      version: 1.2.0
+      specifier: ^1.2.1
+      version: 1.2.1
     '@inox-tools/runtime-logger':
-      specifier: ^0.3.1
-      version: 0.3.1
+      specifier: ^0.3.4
+      version: 0.3.4
     '@markdoc/markdoc':
       specifier: ^0.4.0
       version: 0.4.0
@@ -195,8 +195,8 @@ catalogs:
       specifier: ^0.1.2
       version: 0.1.2
     '@noble/hashes':
-      specifier: ^1.4.0
-      version: 1.4.0
+      specifier: ^1.5.0
+      version: 1.5.0
     '@types/micromatch':
       specifier: ^4.0.9
       version: 4.0.9
@@ -225,8 +225,8 @@ catalogs:
       specifier: ^13.0.2
       version: 13.0.3
     micromatch:
-      specifier: ^4.0.7
-      version: 4.0.7
+      specifier: ^4.0.8
+      version: 4.0.8
     mrmime:
       specifier: ^2.0.0
       version: 2.0.0
@@ -279,10 +279,10 @@ importers:
         version: 0.14.2(@cloudflare/workers-types@4.20240725.0)(@types/react@18.3.5)(react@18.3.1)
       '@cloudinary/url-gen':
         specifier: catalog:studiocms-imagehandler
-        version: 1.19.0
+        version: 1.21.0
       '@inox-tools/runtime-logger':
         specifier: catalog:studiocms-shared
-        version: 0.3.1(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+        version: 0.3.4(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       '@markdoc/markdoc':
         specifier: catalog:studiocms-shared
         version: 0.4.0(@types/react@18.3.5)(react@18.3.1)
@@ -297,7 +297,7 @@ importers:
         version: 0.1.2(daisyui@4.12.10(postcss@8.4.47))(unocss@0.62.3(postcss@8.4.47)(rollup@4.21.0)(vite@5.4.8(@types/node@22.0.0)))
       '@noble/hashes':
         specifier: catalog:studiocms-shared
-        version: 1.4.0
+        version: 1.5.0
       '@shikijs/transformers':
         specifier: catalog:studiocms-renderer
         version: 1.14.1
@@ -339,7 +339,7 @@ importers:
         version: 0.62.3
       '@unpic/astro':
         specifier: catalog:studiocms-imagehandler
-        version: 0.0.46(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+        version: 0.0.47(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       arctic:
         specifier: catalog:studiocms-shared
         version: 1.9.2
@@ -375,7 +375,7 @@ importers:
         version: 1.1.7(marked@13.0.3)
       micromatch:
         specifier: catalog:studiocms-shared
-        version: 4.0.7
+        version: 4.0.8
       mrmime:
         specifier: catalog:studiocms-shared
         version: 2.0.0
@@ -428,7 +428,7 @@ importers:
         version: 0.14.2(@cloudflare/workers-types@4.20240725.0)(@types/react@18.3.5)(react@18.3.1)
       '@inox-tools/runtime-logger':
         specifier: catalog:studiocms-shared
-        version: 0.3.1(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+        version: 0.3.4(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       '@matthiesenxyz/astrodtsbuilder':
         specifier: catalog:studiocms-shared
         version: 0.1.2(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
@@ -440,7 +440,7 @@ importers:
         version: 0.2.0(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       '@noble/hashes':
         specifier: catalog:studiocms-shared
-        version: 1.4.0
+        version: 1.5.0
       '@studiocms/assets':
         specifier: workspace:*
         version: link:../studiocms_assets
@@ -464,7 +464,7 @@ importers:
         version: 3.2.0
       micromatch:
         specifier: catalog:studiocms-shared
-        version: 4.0.7
+        version: 4.0.8
     devDependencies:
       '@types/micromatch':
         specifier: catalog:studiocms-shared
@@ -536,7 +536,7 @@ importers:
         version: 0.2.0(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       '@noble/hashes':
         specifier: catalog:studiocms-shared
-        version: 1.4.0
+        version: 1.5.0
       '@studiocms/robotstxt':
         specifier: workspace:*
         version: link:../studiocms_robotstxt
@@ -582,7 +582,7 @@ importers:
     dependencies:
       '@inox-tools/runtime-logger':
         specifier: catalog:studiocms-shared
-        version: 0.3.1(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+        version: 0.3.4(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       '@matthiesenxyz/astrodtsbuilder':
         specifier: catalog:studiocms-shared
         version: 0.1.2(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
@@ -597,7 +597,7 @@ importers:
         version: 0.1.2(daisyui@4.12.10(postcss@8.4.47))(unocss@0.62.3(postcss@8.4.47)(rollup@4.21.0)(vite@5.4.8(@types/node@22.0.0)))
       '@noble/hashes':
         specifier: catalog:studiocms-shared
-        version: 1.4.0
+        version: 1.5.0
       '@studiocms/assets':
         specifier: workspace:*
         version: link:../studiocms_assets
@@ -705,7 +705,7 @@ importers:
     dependencies:
       '@cloudinary/url-gen':
         specifier: catalog:studiocms-imagehandler
-        version: 1.19.0
+        version: 1.21.0
       '@matthiesenxyz/astrodtsbuilder':
         specifier: catalog:studiocms-shared
         version: 0.1.2(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
@@ -717,7 +717,7 @@ importers:
         version: link:../studiocms_core
       '@unpic/astro':
         specifier: catalog:studiocms-imagehandler
-        version: 0.0.46(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+        version: 0.0.47(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       astro:
         specifier: catalog:min
         version: 4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
@@ -745,7 +745,7 @@ importers:
         version: 3.6.2(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.4.8(@types/node@22.0.0))
       '@inox-tools/runtime-logger':
         specifier: catalog:studiocms-shared
-        version: 0.3.1(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+        version: 0.3.4(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       '@markdoc/markdoc':
         specifier: catalog:studiocms-shared
         version: 0.4.0(@types/react@18.3.5)(react@18.3.1)
@@ -849,7 +849,7 @@ importers:
         version: 0.14.2(@cloudflare/workers-types@4.20240725.0)(@types/react@18.3.5)(react@18.3.1)
       '@astrojs/node':
         specifier: 'catalog:'
-        version: 8.3.3(astro@4.16.3(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3))
+        version: 8.3.4(astro@4.16.6(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3))
       '@astrojs/web-vitals':
         specifier: 'catalog:'
         version: 3.0.0(@astrojs/db@0.14.2(@cloudflare/workers-types@4.20240725.0)(@types/react@18.3.5)(react@18.3.1))
@@ -861,7 +861,7 @@ importers:
         version: link:../../packages/studiocms_devapps
       astro:
         specifier: 'catalog:'
-        version: 4.16.3(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3)
+        version: 4.16.6(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3)
       studiocms:
         specifier: workspace:*
         version: link:../../packages/studiocms
@@ -877,7 +877,7 @@ importers:
     dependencies:
       '@astrojs/node':
         specifier: 'catalog:'
-        version: 8.3.3(astro@4.16.3(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3))
+        version: 8.3.4(astro@4.16.6(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3))
       '@fontsource-variable/onest':
         specifier: 5.1.0
         version: 5.1.0
@@ -886,7 +886,7 @@ importers:
         version: link:../../packages/studiocms_ui
       astro:
         specifier: 'catalog:'
-        version: 4.16.3(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3)
+        version: 4.16.6(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -902,19 +902,19 @@ importers:
         version: 4.0.1
       '@astrojs/check':
         specifier: 'catalog:'
-        version: 0.9.3(typescript@5.6.3)
+        version: 0.9.4(typescript@5.6.3)
       '@astrojs/db':
         specifier: 'catalog:'
         version: 0.14.2(@cloudflare/workers-types@4.20240725.0)(@types/react@18.3.5)(react@18.3.1)
       '@astrojs/node':
         specifier: 'catalog:'
-        version: 8.3.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+        version: 8.3.4(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       '@astrojs/react':
         specifier: catalog:studiocms-shared
-        version: 3.6.2(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.4.8(@types/node@22.0.0))
+        version: 3.6.2(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.4.9(@types/node@22.0.0))
       '@astrojs/starlight':
         specifier: 'catalog:'
-        version: 0.28.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+        version: 0.28.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       '@astrojs/web-vitals':
         specifier: 'catalog:'
         version: 3.0.0(@astrojs/db@0.14.2(@cloudflare/workers-types@4.20240725.0)(@types/react@18.3.5)(react@18.3.1))
@@ -923,7 +923,7 @@ importers:
         version: 5.1.0
       '@lorenzo_lewis/starlight-utils':
         specifier: catalog:docs
-        version: 0.2.0(@astrojs/starlight@0.28.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)))(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+        version: 0.2.0(@astrojs/starlight@0.28.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)))(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       '@shikijs/transformers':
         specifier: 1.22.0
         version: 1.22.0
@@ -950,16 +950,16 @@ importers:
         version: 3.0.2
       astro:
         specifier: 'catalog:'
-        version: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+        version: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
       astro-embed:
         specifier: catalog:docs
-        version: 0.7.2(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+        version: 0.7.4(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       hast:
         specifier: catalog:docs
         version: 1.0.0
       hast-util-select:
         specifier: catalog:docs
-        version: 6.0.2
+        version: 6.0.3
       hast-util-to-string:
         specifier: ^3.0.1
         version: 3.0.1
@@ -983,7 +983,7 @@ importers:
         version: 6.2.0
       rehype:
         specifier: catalog:docs
-        version: 13.0.1
+        version: 13.0.2
       rehype-autolink-headings:
         specifier: ^7.1.0
         version: 7.1.0
@@ -1004,19 +1004,19 @@ importers:
         version: 0.2.0
       starlight-image-zoom:
         specifier: ^0.8.0
-        version: 0.8.0(@astrojs/starlight@0.28.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)))
+        version: 0.8.0(@astrojs/starlight@0.28.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)))
       starlight-typedoc:
         specifier: catalog:docs
-        version: 0.16.0(@astrojs/starlight@0.28.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)))(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))(typedoc-plugin-markdown@4.2.9(typedoc@0.26.8(typescript@5.6.3)))(typedoc@0.26.8(typescript@5.6.3))
+        version: 0.16.0(@astrojs/starlight@0.28.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)))(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))(typedoc-plugin-markdown@4.2.9(typedoc@0.26.10(typescript@5.6.3)))(typedoc@0.26.10(typescript@5.6.3))
       studiocms:
         specifier: workspace:*
         version: link:../../packages/studiocms
       typedoc:
         specifier: catalog:docs
-        version: 0.26.8(typescript@5.6.3)
+        version: 0.26.10(typescript@5.6.3)
       typedoc-plugin-markdown:
         specifier: catalog:docs
-        version: 4.2.9(typedoc@0.26.8(typescript@5.6.3))
+        version: 4.2.9(typedoc@0.26.10(typescript@5.6.3))
       typescript:
         specifier: 'catalog:'
         version: 5.6.3
@@ -1028,25 +1028,25 @@ importers:
     dependencies:
       '@astrojs/check':
         specifier: 'catalog:'
-        version: 0.9.3(typescript@5.6.3)
+        version: 0.9.4(typescript@5.6.3)
       '@astrojs/tailwind':
         specifier: 'catalog:'
-        version: 5.1.0(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))(tailwindcss@3.4.7)
+        version: 5.1.2(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))(tailwindcss@3.4.14)
       '@fontsource-variable/onest':
         specifier: catalog:studiocms-shared
         version: 5.1.0
       '@iconify-json/heroicons':
         specifier: catalog:studiocms-shared
-        version: 1.2.0
+        version: 1.2.1
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
       '@tailwindcss/typography':
         specifier: catalog:landing
-        version: 0.5.15(tailwindcss@3.4.7)
+        version: 0.5.15(tailwindcss@3.4.14)
       astro:
         specifier: 'catalog:'
-        version: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+        version: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
       astro-icon:
         specifier: catalog:landing
         version: 1.1.1
@@ -1058,7 +1058,7 @@ importers:
         version: 10.18.0
       powerglitch:
         specifier: catalog:landing
-        version: 2.3.3
+        version: 2.3.4
       satori:
         specifier: ^0.11.1
         version: 0.11.1
@@ -1070,13 +1070,13 @@ importers:
         version: 0.33.4
       tailwind-merge:
         specifier: catalog:landing
-        version: 2.5.2
+        version: 2.5.4
       tailwind-scrollbar:
         specifier: catalog:landing
-        version: 3.1.0(tailwindcss@3.4.7)
+        version: 3.1.0(tailwindcss@3.4.14)
       tailwindcss:
         specifier: catalog:landing
-        version: 3.4.7
+        version: 3.4.14
       typescript:
         specifier: 'catalog:'
         version: 5.6.3
@@ -1101,34 +1101,34 @@ packages:
   '@antfu/utils@0.7.10':
     resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
 
-  '@astro-community/astro-embed-integration@0.7.1':
-    resolution: {integrity: sha512-uPpVx/CluktB3nOnCTUB7tQ3jms2acYWTe/JgX5tFqTjjtiL686+FcjOaQ/Ej+FNErdg+36Y66WTeIxlYw4pvQ==}
+  '@astro-community/astro-embed-integration@0.7.2':
+    resolution: {integrity: sha512-R5eyiA01pj400skp6sJY4t01oXtTY+Huv2uR4eWUagaPgOOadu135+UkPXo38+LgZ5voYzZkaGwfTaZj4R0AFg==}
     peerDependencies:
-      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta
+      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta
 
-  '@astro-community/astro-embed-link-preview@0.2.1':
-    resolution: {integrity: sha512-pl+KYhv5l2VpvvSwmZXTrCV+x3FxY3js4FX7/V/ABpLiSUsgF0yno90m0qd4Hx2y0XoeC4b/TB4T/Eu4AQIBTQ==}
+  '@astro-community/astro-embed-link-preview@0.2.2':
+    resolution: {integrity: sha512-eZ/ORqtPCC3Z2cSH6UvOB1w9CBguEQUC4nFdyLmwHYIR3FhkutQgbaP7fgI1r+qUBDbXImpZjYxKS3RB4m/fOA==}
 
-  '@astro-community/astro-embed-twitter@0.5.4':
-    resolution: {integrity: sha512-wQyros0Uh4L8fDOCZ9+UYMoq4u+YiJZEvjnL6ZP0KL6dcsyfma/XC2/Q2DBL5SBBiIkkFcFHmzDBIPl4HsENXw==}
+  '@astro-community/astro-embed-twitter@0.5.6':
+    resolution: {integrity: sha512-ywUjNhYbGW17vAQXj2tMus9JvLw8cwgzMshu6tVkzSRlyOoLFeWSNKwe44sU7REhUgmTCEQOUUfleN1j1Zwd4Q==}
     peerDependencies:
-      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta
+      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta
 
   '@astro-community/astro-embed-utils@0.1.3':
     resolution: {integrity: sha512-eiMO+vfCdE9GtW6qE7X5Xl6YCKZDCoXJEWqRofQcoC3GHjqN2/WhJlnaxNVRq3demSO03UNtho57Em5p7o7AOA==}
 
-  '@astro-community/astro-embed-vimeo@0.3.7':
-    resolution: {integrity: sha512-0Y08IOudqSLC/RKiYZagaG/uvfblSt7of+hrIcRky7u+KZK3VrTbZ/Np+nIq81jXLGJQPXN8TNGsOUsY0mw9lw==}
+  '@astro-community/astro-embed-vimeo@0.3.10':
+    resolution: {integrity: sha512-H7v8BozWXG+EhIOn1DcNKLRO6z3bNXZVESUR25mNFiDd3Ue8MEzp8mWkBeRd6Y2onV9acxR34ZhXN36fsSb8bA==}
     peerDependencies:
-      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta
+      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta
 
-  '@astro-community/astro-embed-youtube@0.5.2':
-    resolution: {integrity: sha512-cckWcq7mFCmI6uPpIlRolSafSQRYZBOaxIc8DaCUh8+JQAtPF7O4EdpRpZBUcvbARrWEEyHJCWrt0XOGppMniw==}
+  '@astro-community/astro-embed-youtube@0.5.5':
+    resolution: {integrity: sha512-pG9uYjyZB1kpW8Ljy/H1Klof2txVXLwQmyoG4XWblZyt9eqFlaa65MdzL7UKzzqdoOsn64TN+Q+zPbx0HJhP4Q==}
     peerDependencies:
-      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta
+      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta
 
-  '@astrojs/check@0.9.3':
-    resolution: {integrity: sha512-I6Dz45bMI5YRbp4yK2LKWsHH3/kkHRGdPGruGkLap6pqxhdcNh7oCgN04Ac+haDfc9ow5BYPGPmEhkwef15GQQ==}
+  '@astrojs/check@0.9.4':
+    resolution: {integrity: sha512-IOheHwCtpUfvogHHsvu0AbeRZEnjJg3MopdLddkJE70mULItS/Vh37BHcI00mcOJcH1vhD3odbpvWokpxam7xA==}
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -1142,8 +1142,8 @@ packages:
   '@astrojs/internal-helpers@0.4.1':
     resolution: {integrity: sha512-bMf9jFihO8YP940uD70SI/RDzIhUHJAolWVcO1v5PUivxGKvfLZTLTVVxEYzGYyPsA3ivdLNqMnL5VgmQySa+g==}
 
-  '@astrojs/language-server@2.14.1':
-    resolution: {integrity: sha512-mkKtCTPRD4dyKdAqIP0zmmPyO/ZABOqFESnaVca47Dg/sAagJnDSEsDUDzNbHFh1+9Dj1o5y4iwNsxJboGdaNg==}
+  '@astrojs/language-server@2.15.3':
+    resolution: {integrity: sha512-2qYkHkiqduB2F6OY+zAikd2hZP1xq5LqB0RqLCMoT7KLbfspnx6qtxOueF2n1P4+YUXRHUJVfLA4FoJCEfoMDg==}
     hasBin: true
     peerDependencies:
       prettier: ^3.0.0
@@ -1166,8 +1166,8 @@ packages:
     peerDependencies:
       astro: ^4.8.0
 
-  '@astrojs/node@8.3.3':
-    resolution: {integrity: sha512-idrKhnnPSi0ABV+PCQsRQqVNwpOvVDF/+fkwcIiE8sr9J8EMvW9g/oyAt8T4X2OBJ8FUzYPL8klfCdG7r0eB5g==}
+  '@astrojs/node@8.3.4':
+    resolution: {integrity: sha512-xzQs39goN7xh9np9rypGmbgZj3AmmjNxEMj9ZWz5aBERlqqFF3n8A/w/uaJeZ/bkHS60l1BXVS0tgsQt9MFqBA==}
     peerDependencies:
       astro: ^4.2.0
 
@@ -1198,10 +1198,10 @@ packages:
   '@astrojs/studio@0.1.1':
     resolution: {integrity: sha512-X4PxYQZmkXhgw9rlNKVeCzU6q+U9Cy3k3J5oP4jOTmqTE8TyjCadAad3NweDJCY9Rhgv/w+qhGfjl2JG2lcTaw==}
 
-  '@astrojs/tailwind@5.1.0':
-    resolution: {integrity: sha512-BJoCDKuWhU9FT2qYg+fr6Nfb3qP4ShtyjXGHKA/4mHN94z7BGcmauQK23iy+YH5qWvTnhqkd6mQPQ1yTZTe9Ig==}
+  '@astrojs/tailwind@5.1.2':
+    resolution: {integrity: sha512-IvOF0W/dtHElcXvhrPR35nHmhyV3cfz1EzPitMGtU7sYy9Hci3BNK1To6FWmVuuNKPxza1IgCGetSynJZL7fOg==}
     peerDependencies:
-      astro: ^3.0.0 || ^4.0.0
+      astro: ^3.0.0 || ^4.0.0 || ^5.0.0-beta.0
       tailwindcss: ^3.0.24
 
   '@astrojs/telemetry@3.1.0':
@@ -1238,6 +1238,10 @@ packages:
 
   '@babel/core@7.25.7':
     resolution: {integrity: sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.25.8':
+    resolution: {integrity: sha512-Oixnb+DzmRT30qu9d3tJSQkxuygWm32DFykT4bRoORPa9hZ/L4KhVB/XiRm6KG+roIEM7DBQlmg27kw2HZkdZg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.25.5':
@@ -1374,6 +1378,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.25.8':
+    resolution: {integrity: sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/plugin-syntax-jsx@7.24.7':
     resolution: {integrity: sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==}
     engines: {node: '>=6.9.0'}
@@ -1454,6 +1463,10 @@ packages:
 
   '@babel/types@7.25.7':
     resolution: {integrity: sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.25.8':
+    resolution: {integrity: sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==}
     engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@1.9.3':
@@ -1573,11 +1586,11 @@ packages:
   '@cloudflare/workers-types@4.20240725.0':
     resolution: {integrity: sha512-L6T/Bg50zm9IIACQVQ0CdVcQL+2nLkRXdPz6BsXF3SlzgjyWR5ndVctAbfr/HLV7aKYxWnnEZsIORsTWb+FssA==}
 
-  '@cloudinary/transformation-builder-sdk@1.14.1':
-    resolution: {integrity: sha512-z49To4r3byg7zHsOGKsw/nHef5B9W3wSBdDsGoY7JOj75kbvmSlP4MCkS0JU3Bv57EvYYw5ymalPz+bvRXmPlA==}
+  '@cloudinary/transformation-builder-sdk@1.15.2':
+    resolution: {integrity: sha512-oXYaW/whGaQVlR1O/ocp7vYcxaMAy3uGcQ8+8xjbfDCy/+c+zFIuP6JKI8L05kzqw7Wjh0cqzG+4u0X1UpPh+A==}
 
-  '@cloudinary/url-gen@1.19.0':
-    resolution: {integrity: sha512-3WSqYAMEe8lcYMFmkNPhOfv6Ql76mpf8O7YEC+CCaoIYrfBubzzeF8yENCaZK9tFJEHvMepI+uWWfilNrz48XA==}
+  '@cloudinary/url-gen@1.21.0':
+    resolution: {integrity: sha512-ctYcCzX3G3vcgnESTU2ET3K1XsBiXcEnBddCGV0QbR3fJhLLrIShjSMEwZoepgh4LAFOHJu9DzvLFr+E8R7c7g==}
 
   '@ctrl/tinycolor@4.1.0':
     resolution: {integrity: sha512-WyOx8cJQ+FQus4Mm4uPIZA64gbk3Wxh0so5Lcii0aJifqwoVOlfFtorjLE0Hen4OYyHZMXDWqMmaQemBhgxFRQ==}
@@ -1919,8 +1932,8 @@ packages:
   '@fontsource-variable/onest@5.1.0':
     resolution: {integrity: sha512-8jspwmuPWtC2p4gxmjUIQ2JugqCcClFwlD1DEJt+gARgZMm3PI62rYivoKVUDB3Q6hdQxeL5wdzjxCOnzTU5BA==}
 
-  '@iconify-json/heroicons@1.2.0':
-    resolution: {integrity: sha512-EmvGN0L9EUJCmQ82rkLGZ4tkz0YGQfZV7ugKT6UvHni/bxNitQrD0gLj6NJj2W9zsSoXyNHyCX236+EJmO4pmA==}
+  '@iconify-json/heroicons@1.2.1':
+    resolution: {integrity: sha512-TkKfS5U27kE5MXmSGLzPoz95BP5VA9xEJXwJFwmPMVLX+xyWq0OkoiWTUXB0uAoQODpb8BaRpzSydItrq9fIRA==}
 
   '@iconify/tools@4.0.5':
     resolution: {integrity: sha512-l8KoA1lxlN/FFjlMd3vjfD7BtcX/QnFWtlBapILMlJSBgM5zhDYak/ldw/LkKG3258q/0YmXa48sO/QpxX7ptg==}
@@ -2149,18 +2162,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@inox-tools/modular-station@0.3.0':
-    resolution: {integrity: sha512-aRUm5afEIamsBAkAuD9u3cDsHOwojCOzUdOr7r4dSThM9cV5UkNk8pksGk7VD7OwbTysSadFvZDR6HHvTkaU1g==}
+  '@inox-tools/modular-station@0.3.3':
+    resolution: {integrity: sha512-1I+OE1CmdQ01M7JDZwJKkygknTaSiYJTirdRKMDrRNOVXY+TEx4JqRPSmgfyB1v8ToEiHajwntHHT/e4rN8P2w==}
     peerDependencies:
       astro: ^4.12.2
 
-  '@inox-tools/runtime-logger@0.3.1':
-    resolution: {integrity: sha512-ZaV/Ri1bn60AbLeBIgebkGG+b6wfF5aBDkKMf4LqXp41yUWADIDm4nmvjAF9blXpUTWki1j9767rIyaZeXNEAQ==}
+  '@inox-tools/runtime-logger@0.3.4':
+    resolution: {integrity: sha512-GwpmyNNtsBK/RHv+orttcAmpF5hr+O+kJQxooeYLCrnGWBDZ757hJGNlNkKvHC17x2L859F54HrSZC+VviTL6g==}
     peerDependencies:
       astro: ^4
 
-  '@inox-tools/utils@0.1.3':
-    resolution: {integrity: sha512-UhneOA5PwcPhvcvcH1pW9wGZXRKASD7/MWHCrE+DbSzbMhzBTeUn1rKpssys8rDF51pr3FwgLFz1Cvjj2TMIwA==}
+  '@inox-tools/utils@0.2.0':
+    resolution: {integrity: sha512-y6NVLSfK1YziAORdNoMSh+XqkZ95CDsG8rrGx1eOu3qgV9Do7Ipf82sW1d8TvbP58vJ5SnWUEO90riMcP2YjSA==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2357,9 +2370,9 @@ packages:
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
-  '@noble/hashes@1.4.0':
-    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
-    engines: {node: '>= 16'}
+  '@noble/hashes@1.5.0':
+    resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@node-rs/argon2-android-arm-eabi@1.7.0':
     resolution: {integrity: sha512-udDqkr5P9E+wYX1SZwAVPdyfYvaF4ry9Tm+R9LkfSHbzWH0uhU6zjIwNRp7m+n4gx691rk+lqqDAIP8RLKwbhg==}
@@ -3039,10 +3052,10 @@ packages:
     peerDependencies:
       vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0
 
-  '@unpic/astro@0.0.46':
-    resolution: {integrity: sha512-NVMwxA9hA6jC9rUrgUb49szB+3OHjuZHm0D8jUYzcDp8NJ3gdBKf5ujcs/ok6ReTmdkAGIy8WHnwN5ASd8QvsQ==}
+  '@unpic/astro@0.0.47':
+    resolution: {integrity: sha512-V35x+L8hzJ0w+VnoaCNjXOMYbm5B+WTKa3RQxYUw2/hJZ4Jo4a1uqYbiORJO77eGSaJGQBOGB9RT0BWMOmEz9Q==}
     peerDependencies:
-      astro: ^2.0.0 || ^3.0.0 || ^4.0.0
+      astro: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
 
   '@unpic/core@0.0.49':
     resolution: {integrity: sha512-tAqeJRMPF2TrZbSQe74OZ9O5DzKDDUoFwFbZUpjvLcgwGQ/8aleDCb2Iy3bHFJfzzYZ9iHN0hN1VpTlAGQd+ZA==}
@@ -3059,25 +3072,25 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0
 
-  '@volar/kit@2.4.0':
-    resolution: {integrity: sha512-uqwtPKhrbnP+3f8hs+ltDYXLZ6Wdbs54IzkaPocasI4aBhqWLht5qXctE1MqpZU52wbH359E0u9nhxEFmyon+w==}
+  '@volar/kit@2.4.6':
+    resolution: {integrity: sha512-OaMtpmLns6IYD1nOSd0NdG/F5KzJ7Jr4B7TLeb4byPzu+ExuuRVeO56Dn1C7Frnw6bGudUQd90cpQAmxdB+RlQ==}
     peerDependencies:
       typescript: '*'
 
-  '@volar/language-core@2.4.0':
-    resolution: {integrity: sha512-FTla+khE+sYK0qJP+6hwPAAUwiNHVMph4RUXpxf/FIPKUP61NFrVZorml4mjFShnueR2y9/j8/vnh09YwVdH7A==}
+  '@volar/language-core@2.4.6':
+    resolution: {integrity: sha512-FxUfxaB8sCqvY46YjyAAV6c3mMIq/NWQMVvJ+uS4yxr1KzOvyg61gAuOnNvgCvO4TZ7HcLExBEsWcDu4+K4E8A==}
 
-  '@volar/language-server@2.4.0':
-    resolution: {integrity: sha512-rmGIjAxWekWQiGH97Mosb4juiD/hfFYNQKV5Py9r7vDOLSkbIwRhITbwHm88NJKs8P6TNc6w/PfBXN6yjKadJg==}
+  '@volar/language-server@2.4.6':
+    resolution: {integrity: sha512-ARIbMXapEUPj9UFbZqWqw/iZ+ZuxUcY+vY212+2uutZVo/jrdzhLPu2TfZd9oB9akX8XXuslinT3051DyHLLRA==}
 
-  '@volar/language-service@2.4.0':
-    resolution: {integrity: sha512-4P3yeQXIL68mLfS3n6P3m02IRg3GnLHUU9k/1PCHEfm5FG9bySkDOc72dbBn2vAa2BxOqm18bmmZXrsWuQ5AOw==}
+  '@volar/language-service@2.4.6':
+    resolution: {integrity: sha512-wNeEVBgBKgpP1MfMYPrgTf1K8nhOGEh3ac0+9n6ECyk2N03+j0pWCpQ2i99mRWT/POvo1PgizDmYFH8S67bZOA==}
 
-  '@volar/source-map@2.4.0':
-    resolution: {integrity: sha512-2ceY8/NEZvN6F44TXw2qRP6AQsvCYhV2bxaBPWxV9HqIfkbRydSksTFObCF1DBDNBfKiZTS8G/4vqV6cvjdOIQ==}
+  '@volar/source-map@2.4.6':
+    resolution: {integrity: sha512-Nsh7UW2ruK+uURIPzjJgF0YRGP5CX9nQHypA2OMqdM2FKy7rh+uv3XgPnWPw30JADbKvZ5HuBzG4gSbVDYVtiw==}
 
-  '@volar/typescript@2.4.0':
-    resolution: {integrity: sha512-9zx3lQWgHmVd+JRRAHUSRiEhe4TlzL7U7e6ulWXOxHH/WNYxzKwCvZD7WYWEZFdw4dHfTD9vUR0yPQO6GilCaQ==}
+  '@volar/typescript@2.4.6':
+    resolution: {integrity: sha512-NMIrA7y5OOqddL9VtngPWYmdQU03htNKFtAYidbYfWA0TOhyGVd9tfcP4TsLWQ+RBWDZCbBqsr8xzU0ZOxYTCQ==}
 
   '@vscode/emmet-helper@2.9.3':
     resolution: {integrity: sha512-rB39LHWWPQYYlYfpv9qCoZOVioPCftKXXqrsyqN1mTWZM6dTnONT63Db+03vgrBbHzJN45IrgS/AGxw9iiqfEw==}
@@ -3169,10 +3182,10 @@ packages:
     peerDependencies:
       astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta
 
-  astro-embed@0.7.2:
-    resolution: {integrity: sha512-v/j6yRA9Wa+TEHBV64dQU5bLKuYiy1mNudiKIM+nvFe1bAUh+4wzQOf3lRofrxyBMgHaZbr8Xy7oLS9PVzu5jg==}
+  astro-embed@0.7.4:
+    resolution: {integrity: sha512-meDmEpmwu1wcz1i1KT4yAPJhydq/C4iyh1Pn7sepSbtXF85C05nJoE0cTDJHf0cwM4zMoYTYDluqFIQIfsdhHA==}
     peerDependencies:
-      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta
+      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta
 
   astro-expressive-code@0.35.6:
     resolution: {integrity: sha512-1U4KrvFuodaCV3z4I1bIR16SdhQlPkolGsYTtiANxPZUVv/KitGSCTjzksrkPonn1XuwVqvnwmUUVzTLWngnBA==}
@@ -3220,8 +3233,8 @@ packages:
     engines: {node: ^18.17.1 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
-  astro@4.16.3:
-    resolution: {integrity: sha512-0IrnbCUprAyfeZ8Au/d/d0ssrYGMAZOZ1K3fX7GxI0OwUhkA9bSex0+ywiyVNiVZE5uRlTKRSkvLNKYQWdtHqw==}
+  astro@4.16.6:
+    resolution: {integrity: sha512-LMMbjr+4aN26MOyJzTdjM+Y+srpAIkx7IX9IcdF3eHQLGr8PgkioZp+VQExRfioDIyA2HY6ottVg3QccTzJqYA==}
     engines: {node: ^18.17.1 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -3234,6 +3247,13 @@ packages:
 
   autoprefixer@10.4.19:
     resolution: {integrity: sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
+  autoprefixer@10.4.20:
+    resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
@@ -3377,6 +3397,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chokidar@4.0.1:
+    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
+    engines: {node: '>= 14.16.0'}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -3796,8 +3820,8 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  encodeurl@1.0.2:
-    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
   encoding-sniffer@0.2.0:
@@ -4119,8 +4143,8 @@ packages:
   hast-util-raw@9.0.4:
     resolution: {integrity: sha512-LHE65TD2YiNsHD3YuXcKPHXPLuYh/gjp12mOfU8jxSrm1f/yJpsb0F/KKljS6U9LJoP0Ux+tCe8iJ2AsPzTdgA==}
 
-  hast-util-select@6.0.2:
-    resolution: {integrity: sha512-hT/SD/d/Meu+iobvgkffo1QecV8WeKWxwsNMzcTJsKw1cKTQKSR/7ArJeURLNJF9HDjp9nVoORyNNJxrvBye8Q==}
+  hast-util-select@6.0.3:
+    resolution: {integrity: sha512-OVRQlQ1XuuLP8aFVLYmC2atrfWHS5UD3shonxpnyrjcCkwtvmt/+N6kYJdcY4mkMJhxp4kj2EFIxQ9kvkkt/eQ==}
 
   hast-util-to-estree@3.1.0:
     resolution: {integrity: sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==}
@@ -4440,8 +4464,8 @@ packages:
   lit@3.1.4:
     resolution: {integrity: sha512-q6qKnKXHy2g1kjBaNfcoLlgbI3+aSOZ9Q4tiGa9bGYXq5RBXxkVTqTIVmP2VWMp29L4GyvCFm8ZQ2o56eUAMyA==}
 
-  lite-youtube-embed@0.3.2:
-    resolution: {integrity: sha512-b1dgKyF4PHhinonmr3PB172Nj0qQgA/7DE9EmeIXHR1ksnFEC2olWjNJyJGdsN2cleKHRjjsmrziKlwXtPlmLQ==}
+  lite-youtube-embed@0.3.3:
+    resolution: {integrity: sha512-gFfVVnj6NRjxVfJKo3qoLtpi0v5mn3AcR4eKD45wrxQuxzveFJUb+7Cr6uV6n+DjO8X3p0UzPPquhGt0H/y+NA==}
 
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
@@ -4505,6 +4529,9 @@ packages:
 
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+
+  magic-string@0.30.12:
+    resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
 
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
@@ -4733,10 +4760,6 @@ packages:
   micromark@4.0.0:
     resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
 
-  micromatch@4.0.7:
-    resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
-    engines: {node: '>=8.6'}
-
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -4866,9 +4889,6 @@ packages:
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
-
-  not@0.1.0:
-    resolution: {integrity: sha512-5PDmaAsVfnWUgTUbJ3ERwn7u79Z0dYxN9ErxCpVJJqe2RK0PJ3z+iFUxuqjwtlDDegXvtWoxD/3Fzxox7tFGWA==}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -5125,8 +5145,8 @@ packages:
     resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  powerglitch@2.3.3:
-    resolution: {integrity: sha512-S4XmfeZl0cnD70iZ6cxfU9O3QBWjn09gmHReJW0nQWLcfZQB8a3B9CxmuYZCyvDCXD4o75d9y/qiC+WZtN1IyA==}
+  powerglitch@2.3.4:
+    resolution: {integrity: sha512-QVCs/scRcI9caxykt95civDyZ0L0TahFSP2BU/Mn/db4WweKcT8rUwVdp/O+pr9nF744mVMFoYsMh9Zx7nW3vQ==}
 
   preferred-pm@4.0.0:
     resolution: {integrity: sha512-gYBeFTZLu055D8Vv3cSPox/0iTPtkzxpLroSYYA7WXgRi31WCJ51Uyl8ZiPeUUjyvs2MBzK+S8v9JVUgHU/Sqw==}
@@ -5210,6 +5230,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readdirp@4.0.2:
+    resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
+    engines: {node: '>= 14.16.0'}
+
   recast@0.23.9:
     resolution: {integrity: sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==}
     engines: {node: '>= 4'}
@@ -5260,9 +5284,6 @@ packages:
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
-
-  rehype@13.0.1:
-    resolution: {integrity: sha512-AcSLS2mItY+0fYu9xKxOu1LhUZeBZZBx8//5HKzF+0XP+eP8+6a5MXn2+DW2kfXR6Dtp1FEXMVrjyKAcvcU8vg==}
 
   rehype@13.0.2:
     resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
@@ -5387,8 +5408,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@0.18.0:
-    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
+  send@0.19.1:
+    resolution: {integrity: sha512-p4rRk4f23ynFEfcD9LA0xRYngj+IyGiEYyqqOak8kaN0TvNmuxC2dcVeBn62GpCeR2CpWqyHCNScTP91QbAVFg==}
     engines: {node: '>= 0.8.0'}
 
   server-destroy@1.0.1:
@@ -5575,8 +5596,8 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  tailwind-merge@2.5.2:
-    resolution: {integrity: sha512-kjEBm+pvD+6eAwzJL2Bi+02/9LFLal1Gs61+QB7HvTfQQ0aXwC5LGT8PEt1gS0CWKktKe6ysPTAy3cBC5MeiIg==}
+  tailwind-merge@2.5.4:
+    resolution: {integrity: sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==}
 
   tailwind-scrollbar@3.1.0:
     resolution: {integrity: sha512-pmrtDIZeHyu2idTejfV59SbaJyvp1VRjYxAjZBH0jnyrPRo6HL1kD5Glz8VPagasqr6oAx6M05+Tuw429Z8jxg==}
@@ -5584,8 +5605,8 @@ packages:
     peerDependencies:
       tailwindcss: 3.x
 
-  tailwindcss@3.4.7:
-    resolution: {integrity: sha512-rxWZbe87YJb4OcSopb7up2Ba4U82BoiSGUdoDr3Ydrg9ckxFS/YWsvhN323GMcddgU65QRy7JndC7ahhInhvlQ==}
+  tailwindcss@3.4.14:
+    resolution: {integrity: sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -5662,6 +5683,16 @@ packages:
       typescript:
         optional: true
 
+  tsconfck@3.1.4:
+    resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
@@ -5691,8 +5722,8 @@ packages:
     peerDependencies:
       typedoc: 0.26.x
 
-  typedoc@0.26.8:
-    resolution: {integrity: sha512-QBF0BMbnNeUc6U7pRHY7Jb8pjhmiNWZNQT8LU6uk9qP9t3goP9bJptdlNqMC0wBB2w9sQrxjZt835bpRSSq1LA==}
+  typedoc@0.26.10:
+    resolution: {integrity: sha512-xLmVKJ8S21t+JeuQLNueebEuTVphx6IrP06CdV7+0WVflUSW3SPmR+h1fnWVdAR/FQePEgsSWCUHXqKKjzuUAw==}
     engines: {node: '>= 18'}
     hasBin: true
     peerDependencies:
@@ -5841,10 +5872,49 @@ packages:
       terser:
         optional: true
 
+  vite@5.4.9:
+    resolution: {integrity: sha512-20OVpJHh0PAM0oSOELa5GaZNWeDjcAvQjGXy2Uyr+Tp+/D2/Hdz6NLgpJLsarPTA2QJ6v8mX2P1ZfbsSKvdMkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vitefu@1.0.2:
     resolution: {integrity: sha512-0/iAvbXyM3RiPPJ4lyD4w6Mjgtf4ejTK6TPvTNG3H32PLwuT0N/ZjJLiXug7ETE/LWtTeHw9WRv7uX/tIKYyKg==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  vitefu@1.0.3:
+    resolution: {integrity: sha512-iKKfOMBHob2WxEJbqbJjHAkmYgvFDPhuqrO82om83S8RLk+17FtyMBfcyeH8GqD0ihShtkMW/zzJgiA51hCNCQ==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0-beta.0
     peerDependenciesMeta:
       vite:
         optional: true
@@ -6054,11 +6124,6 @@ packages:
     resolution: {integrity: sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==}
     engines: {node: '>= 14'}
 
-  yaml@2.5.0:
-    resolution: {integrity: sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==}
-    engines: {node: '>= 14'}
-    hasBin: true
-
   yaml@2.5.1:
     resolution: {integrity: sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==}
     engines: {node: '>= 14'}
@@ -6125,45 +6190,44 @@ snapshots:
 
   '@antfu/utils@0.7.10': {}
 
-  '@astro-community/astro-embed-integration@0.7.1(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
+  '@astro-community/astro-embed-integration@0.7.2(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
     dependencies:
-      '@astro-community/astro-embed-link-preview': 0.2.1
-      '@astro-community/astro-embed-twitter': 0.5.4(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
-      '@astro-community/astro-embed-vimeo': 0.3.7(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
-      '@astro-community/astro-embed-youtube': 0.5.2(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      '@astro-community/astro-embed-link-preview': 0.2.2
+      '@astro-community/astro-embed-twitter': 0.5.6(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      '@astro-community/astro-embed-vimeo': 0.3.10(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      '@astro-community/astro-embed-youtube': 0.5.5(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       '@types/unist': 2.0.10
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
-      astro-auto-import: 0.4.2(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      astro-auto-import: 0.4.2(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       unist-util-select: 4.0.3
 
-  '@astro-community/astro-embed-link-preview@0.2.1':
+  '@astro-community/astro-embed-link-preview@0.2.2':
     dependencies:
       '@astro-community/astro-embed-utils': 0.1.3
 
-  '@astro-community/astro-embed-twitter@0.5.4(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
+  '@astro-community/astro-embed-twitter@0.5.6(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
     dependencies:
       '@astro-community/astro-embed-utils': 0.1.3
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
 
   '@astro-community/astro-embed-utils@0.1.3':
     dependencies:
       linkedom: 0.14.26
 
-  '@astro-community/astro-embed-vimeo@0.3.7(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
+  '@astro-community/astro-embed-vimeo@0.3.10(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
     dependencies:
       '@astro-community/astro-embed-utils': 0.1.3
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
 
-  '@astro-community/astro-embed-youtube@0.5.2(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
+  '@astro-community/astro-embed-youtube@0.5.5(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
     dependencies:
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
-      lite-youtube-embed: 0.3.2
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      lite-youtube-embed: 0.3.3
 
-  '@astrojs/check@0.9.3(typescript@5.6.3)':
+  '@astrojs/check@0.9.4(typescript@5.6.3)':
     dependencies:
-      '@astrojs/language-server': 2.14.1(typescript@5.6.3)
-      chokidar: 3.6.0
-      fast-glob: 3.3.2
+      '@astrojs/language-server': 2.15.3(typescript@5.6.3)
+      chokidar: 4.0.1
       kleur: 4.1.5
       typescript: 5.6.3
       yargs: 17.7.2
@@ -6221,25 +6285,24 @@ snapshots:
 
   '@astrojs/internal-helpers@0.4.1': {}
 
-  '@astrojs/language-server@2.14.1(typescript@5.6.3)':
+  '@astrojs/language-server@2.15.3(typescript@5.6.3)':
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/yaml2ts': 0.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@volar/kit': 2.4.0(typescript@5.6.3)
-      '@volar/language-core': 2.4.0
-      '@volar/language-server': 2.4.0
-      '@volar/language-service': 2.4.0
-      '@volar/typescript': 2.4.0
+      '@volar/kit': 2.4.6(typescript@5.6.3)
+      '@volar/language-core': 2.4.6
+      '@volar/language-server': 2.4.6
+      '@volar/language-service': 2.4.6
       fast-glob: 3.3.2
       muggle-string: 0.4.1
-      volar-service-css: 0.0.61(@volar/language-service@2.4.0)
-      volar-service-emmet: 0.0.61(@volar/language-service@2.4.0)
-      volar-service-html: 0.0.61(@volar/language-service@2.4.0)
-      volar-service-prettier: 0.0.61(@volar/language-service@2.4.0)
-      volar-service-typescript: 0.0.61(@volar/language-service@2.4.0)
-      volar-service-typescript-twoslash-queries: 0.0.61(@volar/language-service@2.4.0)
-      volar-service-yaml: 0.0.61(@volar/language-service@2.4.0)
+      volar-service-css: 0.0.61(@volar/language-service@2.4.6)
+      volar-service-emmet: 0.0.61(@volar/language-service@2.4.6)
+      volar-service-html: 0.0.61(@volar/language-service@2.4.6)
+      volar-service-prettier: 0.0.61(@volar/language-service@2.4.6)
+      volar-service-typescript: 0.0.61(@volar/language-service@2.4.6)
+      volar-service-typescript-twoslash-queries: 0.0.61(@volar/language-service@2.4.6)
+      volar-service-yaml: 0.0.61(@volar/language-service@2.4.6)
       vscode-html-languageservice: 5.3.0
       vscode-uri: 3.0.8
     transitivePeerDependencies:
@@ -6291,12 +6354,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@3.1.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
+  '@astrojs/mdx@3.1.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
     dependencies:
       '@astrojs/markdown-remark': 5.2.0
       '@mdx-js/mdx': 3.0.1
       acorn: 8.12.1
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
       es-module-lexer: 1.5.4
       estree-util-visit: 2.0.0
       github-slugger: 2.0.0
@@ -6312,18 +6375,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/node@8.3.3(astro@4.16.3(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3))':
+  '@astrojs/node@8.3.4(astro@4.16.6(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3))':
     dependencies:
-      astro: 4.16.3(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3)
-      send: 0.18.0
+      astro: 4.16.6(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3)
+      send: 0.19.1
       server-destroy: 1.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/node@8.3.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
+  '@astrojs/node@8.3.4(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
     dependencies:
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
-      send: 0.18.0
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      send: 0.19.1
       server-destroy: 1.0.1
     transitivePeerDependencies:
       - supports-color
@@ -6344,6 +6407,18 @@ snapshots:
       - supports-color
       - vite
 
+  '@astrojs/react@3.6.2(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.4.9(@types/node@22.0.0))':
+    dependencies:
+      '@types/react': 18.3.5
+      '@types/react-dom': 18.3.0
+      '@vitejs/plugin-react': 4.3.1(vite@5.4.9(@types/node@22.0.0))
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      ultrahtml: 1.5.3
+    transitivePeerDependencies:
+      - supports-color
+      - vite
+
   '@astrojs/rss@4.0.7':
     dependencies:
       fast-xml-parser: 4.4.1
@@ -6355,18 +6430,18 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.23.8
 
-  '@astrojs/starlight@0.28.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
+  '@astrojs/starlight@0.28.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
     dependencies:
-      '@astrojs/mdx': 3.1.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      '@astrojs/mdx': 3.1.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       '@astrojs/sitemap': 3.1.6
       '@pagefind/default-ui': 1.1.0
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
-      astro-expressive-code: 0.35.6(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      astro-expressive-code: 0.35.6(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
-      hast-util-select: 6.0.2
+      hast-util-select: 6.0.3
       hast-util-to-string: 3.0.1
       hastscript: 9.0.0
       i18next: 23.15.1
@@ -6389,13 +6464,13 @@ snapshots:
       kleur: 4.1.5
       ora: 8.1.0
 
-  '@astrojs/tailwind@5.1.0(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))(tailwindcss@3.4.7)':
+  '@astrojs/tailwind@5.1.2(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))(tailwindcss@3.4.14)':
     dependencies:
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
-      autoprefixer: 10.4.19(postcss@8.4.47)
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      autoprefixer: 10.4.20(postcss@8.4.47)
       postcss: 8.4.47
       postcss-load-config: 4.0.2(postcss@8.4.47)
-      tailwindcss: 3.4.7
+      tailwindcss: 3.4.14
     transitivePeerDependencies:
       - ts-node
 
@@ -6418,7 +6493,7 @@ snapshots:
 
   '@astrojs/yaml2ts@0.2.1':
     dependencies:
-      yaml: 2.5.0
+      yaml: 2.5.1
 
   '@babel/code-frame@7.24.7':
     dependencies:
@@ -6466,6 +6541,26 @@ snapshots:
       '@babel/template': 7.25.7
       '@babel/traverse': 7.25.7
       '@babel/types': 7.25.7
+      convert-source-map: 2.0.0
+      debug: 4.3.7
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/core@7.25.8':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.25.7
+      '@babel/generator': 7.25.7
+      '@babel/helper-compilation-targets': 7.25.7
+      '@babel/helper-module-transforms': 7.25.7(@babel/core@7.25.8)
+      '@babel/helpers': 7.25.7
+      '@babel/parser': 7.25.8
+      '@babel/template': 7.25.7
+      '@babel/traverse': 7.25.7
+      '@babel/types': 7.25.8
       convert-source-map: 2.0.0
       debug: 4.3.7
       gensync: 1.0.0-beta.2
@@ -6566,6 +6661,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.25.7(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-module-imports': 7.25.7
+      '@babel/helper-simple-access': 7.25.7
+      '@babel/helper-validator-identifier': 7.25.7
+      '@babel/traverse': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-optimise-call-expression@7.24.7':
     dependencies:
       '@babel/types': 7.25.6
@@ -6648,6 +6753,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.25.7
 
+  '@babel/parser@7.25.8':
+    dependencies:
+      '@babel/types': 7.25.8
+
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -6656,6 +6765,11 @@ snapshots:
   '@babel/plugin-syntax-jsx@7.25.7(@babel/core@7.25.7)':
     dependencies:
       '@babel/core': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
+
+  '@babel/plugin-syntax-jsx@7.25.7(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.25.2)':
@@ -6689,6 +6803,17 @@ snapshots:
       '@babel/helper-module-imports': 7.25.7
       '@babel/helper-plugin-utils': 7.25.7
       '@babel/plugin-syntax-jsx': 7.25.7(@babel/core@7.25.7)
+      '@babel/types': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-react-jsx@7.25.7(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-annotate-as-pure': 7.25.7
+      '@babel/helper-module-imports': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/plugin-syntax-jsx': 7.25.7(@babel/core@7.25.8)
       '@babel/types': 7.25.7
     transitivePeerDependencies:
       - supports-color
@@ -6762,6 +6887,12 @@ snapshots:
       to-fast-properties: 2.0.0
 
   '@babel/types@7.25.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.7
+      '@babel/helper-validator-identifier': 7.25.7
+      to-fast-properties: 2.0.0
+
+  '@babel/types@7.25.8':
     dependencies:
       '@babel/helper-string-parser': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
@@ -6962,13 +7093,13 @@ snapshots:
   '@cloudflare/workers-types@4.20240725.0':
     optional: true
 
-  '@cloudinary/transformation-builder-sdk@1.14.1':
+  '@cloudinary/transformation-builder-sdk@1.15.2':
     dependencies:
-      '@cloudinary/url-gen': 1.19.0
+      '@cloudinary/url-gen': 1.21.0
 
-  '@cloudinary/url-gen@1.19.0':
+  '@cloudinary/url-gen@1.21.0':
     dependencies:
-      '@cloudinary/transformation-builder-sdk': 1.14.1
+      '@cloudinary/transformation-builder-sdk': 1.15.2
 
   '@ctrl/tinycolor@4.1.0': {}
 
@@ -7154,7 +7285,7 @@ snapshots:
   '@expressive-code/core@0.35.6':
     dependencies:
       '@ctrl/tinycolor': 4.1.0
-      hast-util-select: 6.0.2
+      hast-util-select: 6.0.3
       hast-util-to-html: 9.0.3
       hast-util-to-text: 4.0.2
       hastscript: 9.0.0
@@ -7189,7 +7320,7 @@ snapshots:
 
   '@fontsource-variable/onest@5.1.0': {}
 
-  '@iconify-json/heroicons@1.2.0':
+  '@iconify-json/heroicons@1.2.1':
     dependencies:
       '@iconify/types': 2.0.0
 
@@ -7374,20 +7505,20 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@inox-tools/modular-station@0.3.0(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
+  '@inox-tools/modular-station@0.3.3(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
     dependencies:
-      '@inox-tools/utils': 0.1.3
+      '@inox-tools/utils': 0.2.0
       astro: 4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
       astro-integration-kit: 0.16.1(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
 
-  '@inox-tools/runtime-logger@0.3.1(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
+  '@inox-tools/runtime-logger@0.3.4(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
     dependencies:
-      '@inox-tools/modular-station': 0.3.0(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
-      '@inox-tools/utils': 0.1.3
+      '@inox-tools/modular-station': 0.3.3(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      '@inox-tools/utils': 0.2.0
       astro: 4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
       astro-integration-kit: 0.16.1(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
 
-  '@inox-tools/utils@0.1.3': {}
+  '@inox-tools/utils@0.2.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -7481,11 +7612,11 @@ snapshots:
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.2.0
 
-  '@lorenzo_lewis/starlight-utils@0.2.0(@astrojs/starlight@0.28.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)))(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
+  '@lorenzo_lewis/starlight-utils@0.2.0(@astrojs/starlight@0.28.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)))(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
     dependencies:
-      '@astrojs/starlight': 0.28.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
-      astro-integration-kit: 0.16.1(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      '@astrojs/starlight': 0.28.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      astro-integration-kit: 0.16.1(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -7640,7 +7771,7 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@noble/hashes@1.4.0': {}
+  '@noble/hashes@1.5.0': {}
 
   '@node-rs/argon2-android-arm-eabi@1.7.0':
     optional: true
@@ -8008,13 +8139,13 @@ snapshots:
       fflate: 0.7.4
       string.prototype.codepointat: 0.2.1
 
-  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.7)':
+  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.14)':
     dependencies:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.7
+      tailwindcss: 3.4.14
 
   '@trysound/sax@0.2.0': {}
 
@@ -8326,7 +8457,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@unpic/astro@0.0.46(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
+  '@unpic/astro@0.0.47(astro@4.16.2(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))':
     dependencies:
       '@unpic/core': 0.0.49
       '@unpic/pixels': 1.2.2
@@ -8359,24 +8490,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@volar/kit@2.4.0(typescript@5.6.3)':
+  '@vitejs/plugin-react@4.3.1(vite@5.4.9(@types/node@22.0.0))':
     dependencies:
-      '@volar/language-service': 2.4.0
-      '@volar/typescript': 2.4.0
+      '@babel/core': 7.25.7
+      '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.25.7)
+      '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.25.7)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.14.2
+      vite: 5.4.9(@types/node@22.0.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@volar/kit@2.4.6(typescript@5.6.3)':
+    dependencies:
+      '@volar/language-service': 2.4.6
+      '@volar/typescript': 2.4.6
       typesafe-path: 0.2.2
       typescript: 5.6.3
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
 
-  '@volar/language-core@2.4.0':
+  '@volar/language-core@2.4.6':
     dependencies:
-      '@volar/source-map': 2.4.0
+      '@volar/source-map': 2.4.6
 
-  '@volar/language-server@2.4.0':
+  '@volar/language-server@2.4.6':
     dependencies:
-      '@volar/language-core': 2.4.0
-      '@volar/language-service': 2.4.0
-      '@volar/typescript': 2.4.0
+      '@volar/language-core': 2.4.6
+      '@volar/language-service': 2.4.6
+      '@volar/typescript': 2.4.6
       path-browserify: 1.0.1
       request-light: 0.7.0
       vscode-languageserver: 9.0.1
@@ -8384,18 +8526,18 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
 
-  '@volar/language-service@2.4.0':
+  '@volar/language-service@2.4.6':
     dependencies:
-      '@volar/language-core': 2.4.0
+      '@volar/language-core': 2.4.6
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
 
-  '@volar/source-map@2.4.0': {}
+  '@volar/source-map@2.4.6': {}
 
-  '@volar/typescript@2.4.0':
+  '@volar/typescript@2.4.6':
     dependencies:
-      '@volar/language-core': 2.4.0
+      '@volar/language-core': 2.4.6
       path-browserify: 1.0.1
       vscode-uri: 3.0.8
 
@@ -8473,24 +8615,24 @@ snapshots:
 
   astring@1.8.6: {}
 
-  astro-auto-import@0.4.2(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)):
+  astro-auto-import@0.4.2(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)):
     dependencies:
       '@types/node': 18.19.42
       acorn: 8.12.1
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
 
-  astro-embed@0.7.2(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)):
+  astro-embed@0.7.4(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)):
     dependencies:
-      '@astro-community/astro-embed-integration': 0.7.1(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
-      '@astro-community/astro-embed-link-preview': 0.2.1
-      '@astro-community/astro-embed-twitter': 0.5.4(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
-      '@astro-community/astro-embed-vimeo': 0.3.7(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
-      '@astro-community/astro-embed-youtube': 0.5.2(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      '@astro-community/astro-embed-integration': 0.7.2(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      '@astro-community/astro-embed-link-preview': 0.2.2
+      '@astro-community/astro-embed-twitter': 0.5.6(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      '@astro-community/astro-embed-vimeo': 0.3.10(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      '@astro-community/astro-embed-youtube': 0.5.5(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
 
-  astro-expressive-code@0.35.6(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)):
+  astro-expressive-code@0.35.6(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)):
     dependencies:
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
       rehype-expressive-code: 0.35.6
 
   astro-icon@1.1.1:
@@ -8514,9 +8656,9 @@ snapshots:
       pathe: 1.1.2
       recast: 0.23.9
 
-  astro-integration-kit@0.16.1(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)):
+  astro-integration-kit@0.16.1(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)):
     dependencies:
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
       pathe: 1.1.2
       recast: 0.23.9
 
@@ -8696,15 +8838,15 @@ snapshots:
       - terser
       - typescript
 
-  astro@4.16.3(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3):
+  astro@4.16.6(@types/node@20.14.13)(rollup@4.21.0)(typescript@5.6.3):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.1
       '@astrojs/markdown-remark': 5.3.0
       '@astrojs/telemetry': 3.1.0
-      '@babel/core': 7.25.7
-      '@babel/plugin-transform-react-jsx': 7.25.7(@babel/core@7.25.7)
-      '@babel/types': 7.25.7
+      '@babel/core': 7.25.8
+      '@babel/plugin-transform-react-jsx': 7.25.7(@babel/core@7.25.8)
+      '@babel/types': 7.25.8
       '@oslojs/encoding': 1.1.0
       '@rollup/pluginutils': 5.1.2(rollup@4.21.0)
       '@types/babel__core': 7.20.5
@@ -8735,7 +8877,7 @@ snapshots:
       http-cache-semantics: 4.1.1
       js-yaml: 4.1.0
       kleur: 4.1.5
-      magic-string: 0.30.11
+      magic-string: 0.30.12
       magicast: 0.3.5
       micromatch: 4.0.8
       mrmime: 2.0.0
@@ -8749,11 +8891,11 @@ snapshots:
       semver: 7.6.3
       shiki: 1.22.0
       tinyexec: 0.3.0
-      tsconfck: 3.1.3(typescript@5.6.3)
+      tsconfck: 3.1.4(typescript@5.6.3)
       unist-util-visit: 5.0.0
       vfile: 6.0.3
-      vite: 5.4.8(@types/node@20.14.13)
-      vitefu: 1.0.2(vite@5.4.8(@types/node@20.14.13))
+      vite: 5.4.9(@types/node@20.14.13)
+      vitefu: 1.0.3(vite@5.4.9(@types/node@20.14.13))
       which-pm: 3.0.0
       xxhash-wasm: 1.0.2
       yargs-parser: 21.1.1
@@ -8775,15 +8917,15 @@ snapshots:
       - terser
       - typescript
 
-  astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3):
+  astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.1
       '@astrojs/markdown-remark': 5.3.0
       '@astrojs/telemetry': 3.1.0
-      '@babel/core': 7.25.7
-      '@babel/plugin-transform-react-jsx': 7.25.7(@babel/core@7.25.7)
-      '@babel/types': 7.25.7
+      '@babel/core': 7.25.8
+      '@babel/plugin-transform-react-jsx': 7.25.7(@babel/core@7.25.8)
+      '@babel/types': 7.25.8
       '@oslojs/encoding': 1.1.0
       '@rollup/pluginutils': 5.1.2(rollup@4.21.0)
       '@types/babel__core': 7.20.5
@@ -8814,7 +8956,7 @@ snapshots:
       http-cache-semantics: 4.1.1
       js-yaml: 4.1.0
       kleur: 4.1.5
-      magic-string: 0.30.11
+      magic-string: 0.30.12
       magicast: 0.3.5
       micromatch: 4.0.8
       mrmime: 2.0.0
@@ -8828,11 +8970,11 @@ snapshots:
       semver: 7.6.3
       shiki: 1.22.0
       tinyexec: 0.3.0
-      tsconfck: 3.1.3(typescript@5.6.3)
+      tsconfck: 3.1.4(typescript@5.6.3)
       unist-util-visit: 5.0.0
       vfile: 6.0.3
-      vite: 5.4.8(@types/node@22.0.0)
-      vitefu: 1.0.2(vite@5.4.8(@types/node@22.0.0))
+      vite: 5.4.9(@types/node@22.0.0)
+      vitefu: 1.0.3(vite@5.4.9(@types/node@22.0.0))
       which-pm: 3.0.0
       xxhash-wasm: 1.0.2
       yargs-parser: 21.1.1
@@ -8862,6 +9004,16 @@ snapshots:
     dependencies:
       browserslist: 4.23.2
       caniuse-lite: 1.0.30001644
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.1.0
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  autoprefixer@10.4.20(postcss@8.4.47):
+    dependencies:
+      browserslist: 4.24.0
+      caniuse-lite: 1.0.30001667
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.0
@@ -9021,6 +9173,10 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chokidar@4.0.1:
+    dependencies:
+      readdirp: 4.0.2
 
   chownr@2.0.0: {}
 
@@ -9296,7 +9452,7 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  encodeurl@1.0.2: {}
+  encodeurl@2.0.0: {}
 
   encoding-sniffer@0.2.0:
     dependencies:
@@ -9708,7 +9864,7 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
-  hast-util-select@6.0.2:
+  hast-util-select@6.0.3:
     dependencies:
       '@types/hast': 3.0.4
       '@types/unist': 3.0.2
@@ -9720,7 +9876,6 @@ snapshots:
       hast-util-has-property: 3.0.0
       hast-util-to-string: 3.0.1
       hast-util-whitespace: 3.0.0
-      not: 0.1.0
       nth-check: 2.1.1
       property-information: 6.5.0
       space-separated-tokens: 2.0.2
@@ -10098,7 +10253,7 @@ snapshots:
       lit-element: 4.0.6
       lit-html: 3.1.4
 
-  lite-youtube-embed@0.3.2: {}
+  lite-youtube-embed@0.3.3: {}
 
   load-tsconfig@0.2.5: {}
 
@@ -10163,6 +10318,10 @@ snapshots:
   lunr@2.3.9: {}
 
   magic-string@0.30.11:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  magic-string@0.30.12:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
@@ -10683,11 +10842,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  micromatch@4.0.7:
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.1
-
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
@@ -10789,8 +10943,6 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
-
-  not@0.1.0: {}
 
   nth-check@2.1.1:
     dependencies:
@@ -11031,7 +11183,7 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.4.47):
     dependencies:
       lilconfig: 3.1.2
-      yaml: 2.5.0
+      yaml: 2.5.1
     optionalDependencies:
       postcss: 8.4.47
 
@@ -11058,7 +11210,7 @@ snapshots:
       picocolors: 1.1.0
       source-map-js: 1.2.1
 
-  powerglitch@2.3.3: {}
+  powerglitch@2.3.4: {}
 
   preferred-pm@4.0.0:
     dependencies:
@@ -11134,6 +11286,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  readdirp@4.0.2: {}
 
   recast@0.23.9:
     dependencies:
@@ -11236,18 +11390,11 @@ snapshots:
       hast-util-to-html: 9.0.3
       unified: 11.0.5
 
-  rehype@13.0.1:
-    dependencies:
-      '@types/hast': 3.0.4
-      rehype-parse: 9.0.0
-      rehype-stringify: 10.0.0
-      unified: 11.0.5
-
   rehype@13.0.2:
     dependencies:
       '@types/hast': 3.0.4
       rehype-parse: 9.0.0
-      rehype-stringify: 10.0.0
+      rehype-stringify: 10.0.1
       unified: 11.0.5
 
   remark-directive@3.0.0:
@@ -11434,12 +11581,12 @@ snapshots:
 
   semver@7.6.3: {}
 
-  send@0.18.0:
+  send@0.19.1:
     dependencies:
       debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
-      encodeurl: 1.0.2
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
       fresh: 0.5.2
@@ -11589,20 +11736,20 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  starlight-image-zoom@0.8.0(@astrojs/starlight@0.28.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))):
+  starlight-image-zoom@0.8.0(@astrojs/starlight@0.28.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))):
     dependencies:
-      '@astrojs/starlight': 0.28.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      '@astrojs/starlight': 0.28.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
       rehype-raw: 7.0.0
       unist-util-visit: 5.0.0
       unist-util-visit-parents: 6.0.1
 
-  starlight-typedoc@0.16.0(@astrojs/starlight@0.28.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)))(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))(typedoc-plugin-markdown@4.2.9(typedoc@0.26.8(typescript@5.6.3)))(typedoc@0.26.8(typescript@5.6.3)):
+  starlight-typedoc@0.16.0(@astrojs/starlight@0.28.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)))(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))(typedoc-plugin-markdown@4.2.9(typedoc@0.26.10(typescript@5.6.3)))(typedoc@0.26.10(typescript@5.6.3)):
     dependencies:
-      '@astrojs/starlight': 0.28.3(astro@4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
-      astro: 4.16.3(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
+      '@astrojs/starlight': 0.28.3(astro@4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3))
+      astro: 4.16.6(@types/node@22.0.0)(rollup@4.21.0)(typescript@5.6.3)
       github-slugger: 2.0.0
-      typedoc: 0.26.8(typescript@5.6.3)
-      typedoc-plugin-markdown: 4.2.9(typedoc@0.26.8(typescript@5.6.3))
+      typedoc: 0.26.10(typescript@5.6.3)
+      typedoc-plugin-markdown: 4.2.9(typedoc@0.26.10(typescript@5.6.3))
 
   statuses@2.0.1: {}
 
@@ -11685,13 +11832,13 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.0
 
-  tailwind-merge@2.5.2: {}
+  tailwind-merge@2.5.4: {}
 
-  tailwind-scrollbar@3.1.0(tailwindcss@3.4.7):
+  tailwind-scrollbar@3.1.0(tailwindcss@3.4.14):
     dependencies:
-      tailwindcss: 3.4.7
+      tailwindcss: 3.4.14
 
-  tailwindcss@3.4.7:
+  tailwindcss@3.4.14:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -11776,6 +11923,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.3
 
+  tsconfck@3.1.4(typescript@5.6.3):
+    optionalDependencies:
+      typescript: 5.6.3
+
   tslib@2.6.3: {}
 
   tsx@4.16.2:
@@ -11801,11 +11952,11 @@ snapshots:
 
   type-fest@4.26.1: {}
 
-  typedoc-plugin-markdown@4.2.9(typedoc@0.26.8(typescript@5.6.3)):
+  typedoc-plugin-markdown@4.2.9(typedoc@0.26.10(typescript@5.6.3)):
     dependencies:
-      typedoc: 0.26.8(typescript@5.6.3)
+      typedoc: 0.26.10(typescript@5.6.3)
 
-  typedoc@0.26.8(typescript@5.6.3):
+  typedoc@0.26.10(typescript@5.6.3):
     dependencies:
       lunr: 2.3.9
       markdown-it: 14.1.0
@@ -11992,6 +12143,24 @@ snapshots:
       '@types/node': 22.0.0
       fsevents: 2.3.3
 
+  vite@5.4.9(@types/node@20.14.13):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.47
+      rollup: 4.21.0
+    optionalDependencies:
+      '@types/node': 20.14.13
+      fsevents: 2.3.3
+
+  vite@5.4.9(@types/node@22.0.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.47
+      rollup: 4.21.0
+    optionalDependencies:
+      '@types/node': 22.0.0
+      fsevents: 2.3.3
+
   vitefu@1.0.2(vite@5.4.8(@types/node@20.14.13)):
     optionalDependencies:
       vite: 5.4.8(@types/node@20.14.13)
@@ -12000,44 +12169,52 @@ snapshots:
     optionalDependencies:
       vite: 5.4.8(@types/node@22.0.0)
 
-  volar-service-css@0.0.61(@volar/language-service@2.4.0):
+  vitefu@1.0.3(vite@5.4.9(@types/node@20.14.13)):
+    optionalDependencies:
+      vite: 5.4.9(@types/node@20.14.13)
+
+  vitefu@1.0.3(vite@5.4.9(@types/node@22.0.0)):
+    optionalDependencies:
+      vite: 5.4.9(@types/node@22.0.0)
+
+  volar-service-css@0.0.61(@volar/language-service@2.4.6):
     dependencies:
       vscode-css-languageservice: 6.3.0
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
     optionalDependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': 2.4.6
 
-  volar-service-emmet@0.0.61(@volar/language-service@2.4.0):
+  volar-service-emmet@0.0.61(@volar/language-service@2.4.6):
     dependencies:
       '@emmetio/css-parser': 0.4.0
       '@emmetio/html-matcher': 1.3.0
       '@vscode/emmet-helper': 2.9.3
       vscode-uri: 3.0.8
     optionalDependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': 2.4.6
 
-  volar-service-html@0.0.61(@volar/language-service@2.4.0):
+  volar-service-html@0.0.61(@volar/language-service@2.4.6):
     dependencies:
       vscode-html-languageservice: 5.3.0
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
     optionalDependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': 2.4.6
 
-  volar-service-prettier@0.0.61(@volar/language-service@2.4.0):
+  volar-service-prettier@0.0.61(@volar/language-service@2.4.6):
     dependencies:
       vscode-uri: 3.0.8
     optionalDependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': 2.4.6
 
-  volar-service-typescript-twoslash-queries@0.0.61(@volar/language-service@2.4.0):
+  volar-service-typescript-twoslash-queries@0.0.61(@volar/language-service@2.4.6):
     dependencies:
       vscode-uri: 3.0.8
     optionalDependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': 2.4.6
 
-  volar-service-typescript@0.0.61(@volar/language-service@2.4.0):
+  volar-service-typescript@0.0.61(@volar/language-service@2.4.6):
     dependencies:
       path-browserify: 1.0.1
       semver: 7.6.3
@@ -12046,14 +12223,14 @@ snapshots:
       vscode-nls: 5.2.0
       vscode-uri: 3.0.8
     optionalDependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': 2.4.6
 
-  volar-service-yaml@0.0.61(@volar/language-service@2.4.0):
+  volar-service-yaml@0.0.61(@volar/language-service@2.4.6):
     dependencies:
       vscode-uri: 3.0.8
       yaml-language-server: 1.15.0
     optionalDependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': 2.4.6
 
   vscode-css-languageservice@6.3.0:
     dependencies:
@@ -12196,8 +12373,6 @@ snapshots:
       prettier: 2.8.7
 
   yaml@2.2.2: {}
-
-  yaml@2.5.0: {}
 
   yaml@2.5.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,13 +2,13 @@ catalog:
   '@astrojs/db': ^0.14.2
   '@astrojs/markdown-remark': ^5.2.0
   '@astrojs/rss': ^4.0.7
-  '@astrojs/check': ^0.9.3
-  '@astrojs/tailwind': ^5.1.0
+  '@astrojs/check': ^0.9.4
+  '@astrojs/tailwind': ^5.1.2
   '@astrojs/starlight': ^0.28.3
   '@astrojs/web-vitals': ^3.0.0
-  '@astrojs/node': ^8.3.3
+  '@astrojs/node': ^8.3.4
   '@types/node': ^20.14.11
-  astro: ^4.16.3
+  astro: ^4.16.6
   astro-integration-kit: ^0.16.1
   astro-theme-provider: ^0.6.1
   sharp: ^0.33.4
@@ -23,9 +23,9 @@ catalogs:
     vite: ^4 || ^5
   landing:
     motion: ^10.18.0
-    powerglitch: ^2.3.3
-    tailwindcss: ^3.4.4
-    tailwind-merge: ^2.5.2
+    powerglitch: ^2.3.4
+    tailwindcss: ^3.4.14
+    tailwind-merge: ^2.5.4
     tailwind-scrollbar: ^3.1.0
     '@tailwindcss/typography': ^0.5.15
     astro-icon: ^1.1.1
@@ -34,15 +34,15 @@ catalogs:
     "@11ty/eleventy-fetch": ^4.0.1
     "@lorenzo_lewis/starlight-utils": ^0.2.0
     "@types/hast": ^3.0.4
-    astro-embed: ^0.7.2
+    astro-embed: ^0.7.4
     hast: ^1.0.0
-    hast-util-select: ^6.0.2
+    hast-util-select: ^6.0.3
     p-retry: ^6.2.0
-    rehype: ^13.0.1
+    rehype: ^13.0.2
     starlight-versions: ^0.3.0
     starlight-package-managers: ^0.7.0
     starlight-typedoc: ^0.16.0
-    typedoc: ^0.26.8
+    typedoc: ^0.26.10
     typedoc-plugin-markdown: ^4.2.9
   studiocms:
     '@types/semver': ^7.5.8
@@ -53,14 +53,14 @@ catalogs:
     mdast-util-to-hast: ^13.2.0
   studiocms-shared:
     '@fontsource-variable/onest': 5.1.0
-    '@inox-tools/runtime-logger': ^0.3.1
-    '@iconify-json/heroicons': ^1.2.0
+    '@inox-tools/runtime-logger': ^0.3.4
+    '@iconify-json/heroicons': ^1.2.1
     "@matthiesenxyz/astrolace": ^0.3.2
     "@matthiesenxyz/astrodtsbuilder": ^0.1.2
     "@matthiesenxyz/integration-utils": ^0.2.0
     '@matthiesenxyz/unocss-preset-daisyui': ^0.1.2
     '@markdoc/markdoc': ^0.4.0
-    '@noble/hashes': ^1.4.0
+    '@noble/hashes': ^1.5.0
     '@unocss/astro': ^0.62.3
     '@unocss/reset': ^0.62.3
     '@types/micromatch': ^4.0.9
@@ -74,7 +74,7 @@ catalogs:
     lucia: ^3.2.0
     arctic: ^1.9.1
     marked: ^13.0.2
-    micromatch: ^4.0.7
+    micromatch: ^4.0.8
     shiki: ^1.14.1
     unpic: ^3.18.0
     mrmime: ^2.0.0
@@ -90,8 +90,8 @@ catalogs:
     remark-gfm: ^4.0.0
     rehype-highlight: ^7.0.0
   studiocms-imagehandler:
-    '@cloudinary/url-gen': ^1.19.0
-    '@unpic/astro': ^0.0.46
+    '@cloudinary/url-gen': ^1.21.0
+    '@unpic/astro': ^0.0.47
 
 packages:
   - "packages/*"


### PR DESCRIPTION
This pull request includes updates to various dependencies in the `pnpm-workspace.yaml` file, ensuring that the project uses the latest versions of these packages.

Dependency updates:

* Updated versions for `@astrojs/check`, `@astrojs/tailwind`, `@astrojs/node`, and `astro` in the `catalog:` section. (`pnpm-workspace.yaml` [pnpm-workspace.yamlL5-R11](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL5-R11))
* Updated versions for `powerglitch`, `tailwindcss`, and `tailwind-merge` in the `catalogs:` section under `landing`. (`pnpm-workspace.yaml` [pnpm-workspace.yamlL26-R28](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL26-R28))
* Updated versions for `astro-embed`, `hast-util-select`, `rehype`, and `typedoc` in the `catalogs:` section. (`pnpm-workspace.yaml` [pnpm-workspace.yamlL37-R45](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL37-R45))
* Updated versions for `@inox-tools/runtime-logger`, `@iconify-json/heroicons`, and `@noble/hashes` in the `catalogs:` section under `studiocms-shared`. (`pnpm-workspace.yaml` [pnpm-workspace.yamlL56-R63](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL56-R63))
* Updated versions for `micromatch` in the `catalogs:` section. (`pnpm-workspace.yaml` [pnpm-workspace.yamlL77-R77](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL77-R77))
* Updated versions for `@cloudinary/url-gen` and `@unpic/astro` in the `catalogs:` section under `studiocms-imagehandler`. (`pnpm-workspace.yaml` [pnpm-workspace.yamlL93-R94](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL93-R94))