### PR TITLE
Investigate deployment issue with Powerglitch

### DIFF
--- a/www/web/src/pages/index.astro
+++ b/www/web/src/pages/index.astro
@@ -19,7 +19,7 @@ const features = (await getCollection('features')).sort(
 ---
 
 <script>
-  import { PowerGlitch } from 'powerglitch'
+  // import { PowerGlitch } from 'powerglitch' // is this even used?
   import { animate, inView } from 'motion'
 
   // DOM Nodes
@@ -27,7 +27,7 @@ const features = (await getCollection('features')).sort(
   inView(hero, () => {
     animate(hero, { opacity: [0, 1], y: [60, 0] }, { duration: 2 })
   })
-  PowerGlitch.glitch('.glitch')
+  // PowerGlitch.glitch('.glitch')
 </script>
 
 <BaseLayout>


### PR DESCRIPTION
```bash
#17 25.61 src/pages/index.astro:22:31 - error ts(7016): Could not find a declaration file for module 'powerglitch'. '/app/node_modules/.pnpm/powerglitch@2.3.4/node_modules/powerglitch/lib/index.esm.js' implicitly has an 'any' type.
#17 25.61   There are types at '/app/www/web/node_modules/powerglitch/build/src/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'powerglitch' library may need to update its package.json or typings.
#17 25.61 
#17 25.61 22   import { PowerGlitch } from 'powerglitch'
#17 25.61 
```
After the last merge we got this from our deployment system.  I've done some looking to try to find any usage of powerglitch and it only seems to be initialized on the index page within a script tag but not actually used anywhere else.

Due to not seeing any usage of the defined powerglitch class i have disabled powerglitch.