### PR TITLE
Update toast outlines for persistent toasts

### DIFF
--- a/.changeset/thick-dryers-train.md
+++ b/.changeset/thick-dryers-train.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+Adjusted persistent toasts to include an outline for better visibility

--- a/packages/studiocms_ui/src/components/Toast/Toaster.astro
+++ b/packages/studiocms_ui/src/components/Toast/Toaster.astro
@@ -71,7 +71,7 @@ const {
     const toastContainer = document.createElement('div');
     const toastID = generateID('toast');
     toastContainer.id = toastID;
-    toastContainer.classList.add('toast-container', props.type, `${props.closeButton || props.persistent && "closeable"}`);
+    toastContainer.classList.add('toast-container', props.type, `${props.closeButton || props.persistent && "closeable"}`, `${props.persistent && 'persistent'}`);
 
     const toastHeader = document.createElement('div');
     toastHeader.classList.add('toast-header');
@@ -260,6 +260,22 @@ const {
 
   .toast-container.closing {
     animation: toast-closing .25s ease forwards;
+  }
+
+  .toast-container.persistent {
+    border: 1px solid hsl(var(--primary-base));
+  }
+
+  .toast-container.persistent.success {
+    border: 1px solid hsl(var(--success-base));
+  }
+
+  .toast-container.persistent.warning {
+    border: 1px solid hsl(var(--warning-base));
+  }
+
+  .toast-container.persistent.danger {
+    border: 1px solid hsl(var(--danger-base));
   }
 
   @keyframes toast-pop-in {


### PR DESCRIPTION
#### Description

- Improves toasts by adding an outline to persistent toasts, which were barely visible due to not having a colored progress bar.

![image](https://github.com/user-attachments/assets/646e6a08-e36c-49b0-87a5-7eacc8225eb6)
