### PR TITLE
Translations update from StudioCMS i18n

### DIFF
--- a/packages/studiocms_core/src/i18n/translations/es.json
+++ b/packages/studiocms_core/src/i18n/translations/es.json
@@ -1,0 +1,43 @@
+{
+    "displayName": "",
+    "translations": {
+        "@studiocms/auth:login": {
+            "title": "",
+            "description": "",
+            "header": "",
+            "sub-header-usernamepasswordoauth": "",
+            "sub-header-usernamepassword": "",
+            "sub-header-oauth": "",
+            "sub-header-noprovider": "",
+            "username-label": "",
+            "password-label": "",
+            "login-button": "",
+            "allow-registration-noaccount": "",
+            "allow-registration-register": ""
+        },
+        "@studiocms/auth:signup": {
+            "title": "",
+            "description": "",
+            "header": "",
+            "sub-header-usernamepasswordoauth": "",
+            "sub-header-usernamepassword": "",
+            "sub-header-oauth": "",
+            "sub-header-noprovider": "",
+            "username-label": "",
+            "email-label": "",
+            "displayname-label": "",
+            "password-label": "",
+            "confirm-password-label": "",
+            "create-account-button": "",
+            "allow-login-haveaccount": "",
+            "allow-login-login": ""
+        },
+        "@studiocms/auth:logout": {
+            "title": "",
+            "description": ""
+        },
+        "@studiocms/auth:oauth-stack": {
+            "or-login-with": ""
+        }
+    }
+}


### PR DESCRIPTION
Translations update from [StudioCMS i18n](https://i18n.studiocms.xyz) for [StudioCMS/StudioCMS Dashboard (test)](https://i18n.studiocms.xyz/projects/studiocms/studiocms-dashboard-test/).



Current translation status:

![Weblate translation status](https://i18n.studiocms.xyz/widget/studiocms/studiocms-dashboard-test/horizontal-auto.svg)